### PR TITLE
Updates scaffold for content.js

### DIFF
--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -69,10 +69,6 @@ jobs:
           path: ${{ github.workspace }}/${{ inputs.prebuild }}
           persist-credentials: false
 
-      - name: Temp sources override
-        shell: bash
-        run: cp -f ${{ github.workspace }}/wordlake/.scaffold/sources.json ${{ github.workspace }}/docs.elastic.co/.
-
       - name: Show current workspace
         shell: bash
         run: ls -lat 

--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Temp sources override
         shell: bash
-        run: cp -f ${{ github.workspace }}/wordlake-dev/.scaffold/sources.json ${{ github.workspace }}/docs.elastic.dev/.
+        run: cp -f ${{ github.workspace }}/wordlake-dev/.scaffold/content.js ${{ github.workspace }}/docs.elastic.dev/config/.
 
       - name: Portal
         shell: bash


### PR DESCRIPTION
1. Removes line from co runner, as it was unused as the app is correct
2. Updates dev line to move from scaffold to config/. in the dev doc app

⚠️ Now requires we update `.scaffold/content.js` in parity with `content.js` nav items in docs.elastic.dev!