### PR TITLE
Add condition to prevent deploy on non-default merge

### DIFF
--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -114,7 +114,7 @@ jobs:
               core.setFailed('Deploy failed, help available in #next-docs')
 
       - name: Portal for deploy
-        if: github.event.pull_request.merged == true && github.event.pull_request.base.ref != github.event.pull_request.base.repo.default_branch
+        if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch
         shell: bash
         run: |
           cd ${{ github.workspace }}/${{ inputs.prebuild }}

--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -114,7 +114,7 @@ jobs:
               core.setFailed('Deploy failed, help available in #next-docs')
 
       - name: Portal for deploy
-        if: github.event.pull_request.merged == true
+        if: github.event.pull_request.merged == true && github.event.pull_request.base.ref != github.event.pull_request.base.repo.default_branch
         shell: bash
         run: |
           cd ${{ github.workspace }}/${{ inputs.prebuild }}


### PR DESCRIPTION
We recently had an issue where a docsmobile consumer triggered a merge to a feature branch, which triggered a deploy of docs that weren't supposed to go live yet. This PR adds a check to endure that the deploy is happening on the default branch before proceeding. 