### PR TITLE
Disable `continue-on-error` for previews

### DIFF
--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -96,7 +96,7 @@ jobs:
         if: github.event.pull_request.merged != true && github.event.pull_request.closed != true
         id: vercel-deploy
         uses: elastic/builder@v21.5.0
-        continue-on-error: true
+        continue-on-error: false
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
@@ -105,14 +105,6 @@ jobs:
           working-directory: ./
           github-token: ${{ secrets.VERCEL_GITHUB_TOKEN }} #Optional 
           github-comment: true # Otherwise need github-token (VERCEL_GITHUB_TOKEN)
-
-      - name: Declare Vercel failure
-        if: github.event.pull_request.merged != true && steps.vercel-deploy.outcome != 'success' && steps.vercel-deploy.outcome != 'skipped'  
-        id: vercel-failure
-        uses: actions/github-script@v3
-        with:
-          script: |
-              core.setFailed('Deploy failed, help available in #next-docs')
 
       - name: Portal for deploy
         if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch

--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -117,14 +117,6 @@ jobs:
           github-token: ${{ secrets.VERCEL_GITHUB_TOKEN }} #Optional 
           github-comment: false # Otherwise need github-token (VERCEL_GITHUB_TOKEN)
 
-      - name: Declare Vercel failure
-        if: github.event.pull_request.merged != true && steps.vercel-deploy.outcome != 'success' && steps.vercel-deploy.outcome != 'skipped'  
-        id: vercel-failure
-        uses: actions/github-script@v3
-        with:
-          script: |
-              core.setFailed('Deploy failed, please run the build locally to determine issue.')
-
       - name: Portal for deploy
         if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch
         shell: bash

--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -107,7 +107,7 @@ jobs:
         if: github.event.pull_request.merged != true && github.event.pull_request.closed != true
         id: vercel-deploy
         uses: elastic/builder@v21.5.0
-        continue-on-error: true
+        continue-on-error: false
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required


### PR DESCRIPTION
There's no easy way for a writer to know why their build failed, and this will at least expose a link to Vercel that's more informative than the current state, which adds no value.

**Before**
![image](https://user-images.githubusercontent.com/1869731/207396274-0d33d76a-6456-4d35-9aba-5c7016a5c305.png)

**After**
![image](https://user-images.githubusercontent.com/1869731/207398288-0f292381-9285-4285-aff4-f4c47b8c06cb.png)

Clicking any of the links in the previous screenshot will take you to the Vercel logs, which show actionable errors:

![image](https://user-images.githubusercontent.com/1869731/207397390-c336c83b-ebce-4ea8-9462-3f50a0696139.png)
