### PR TITLE
Update `docs-elastic-co-publish.yml` to use wordlake `content.js` data

### DIFF
--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Show current workspace
         shell: bash
         run: ls -lat 
+       
+      - name: Temp sources override
+        shell: bash
+        run: cp -f ${{ github.workspace }}/wordlake/.scaffold/content.js ${{ github.workspace }}/docs.elastic.co/config/. 
 
       - name: Portal
         shell: bash


### PR DESCRIPTION
This PR enables the ability of PR previews to be updated with the latest content and not what is currently live