### PR TITLE
Create docs-elastic-staging-publish.yml

### DIFF
--- a/.github/workflows/docs-elastic-staging-publish.yml
+++ b/.github/workflows/docs-elastic-staging-publish.yml
@@ -1,0 +1,130 @@
+name: builder
+
+on:
+  workflow_call:
+    inputs:
+      prebuild: 
+        type: string
+        required: true
+      project-name: 
+        type: string
+        required: true
+      repo: 
+        type: string
+        required: true
+    secrets:
+      VERCEL_GITHUB_TOKEN:
+        description: 'A GitHub PAT with repo scope'
+        required: true
+      VERCEL_TOKEN:
+        description: 'Vercel API token, account level'
+        required: true
+      VERCEL_ORG_ID:
+        description: 'Vercel ORG token, org level'
+        required: true
+      VERCEL_PROJECT_ID_STAGING_PREVIEW_DOCS:
+        description: 'Vercel PROJECT token, project level'
+        required: true
+
+jobs:
+  preview:
+    name: doc builder
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Setup workspace
+        uses: actions/checkout@v3.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout branch into temp
+        if: github.event.action != 'closed' && github.event.pull_request.merged != true
+        uses: actions/checkout@v3.0.1
+        with:
+          path: 'tmp'
+          fetch-depth: 2
+          ref: refs/pull/${{ github.event.number }}/head
+          persist-credentials: false
+
+      - name: Prepare content for deploy
+        if: ${{ github.event.pull_request.merged }}
+        uses: actions/checkout@v3.0.1
+        with:
+          path: 'tmp'
+          persist-credentials: false
+
+      - name: Checkout dev doc docsmobile app
+        uses: actions/checkout@v3.0.1
+        with:
+          repository: elastic/${{ inputs.repo }}
+          token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
+          path: ${{ github.workspace }}/${{ inputs.repo }}
+          persist-credentials: false
+
+      - name: Checkout Wordlake-staging
+        uses: actions/checkout@v3.0.1
+        with:
+          repository: elastic/${{ inputs.prebuild }}
+          token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
+          path: ${{ github.workspace }}/${{ inputs.prebuild }}
+
+      - name: Temp sources override
+        shell: bash
+        run: cp -f ${{ github.workspace }}/wordlake-staging/.scaffold/content.js ${{ github.workspace }}/docsstaging.elastic.dev/config/.
+
+      - name: Portal
+        shell: bash
+        run: |
+          mkdir -p ${{ github.workspace }}/${{ inputs.prebuild }}/${{ github.event.repository.name }}
+          rm -rf ${{ github.workspace }}/${{ inputs.prebuild }}/${{ github.event.repository.name }}/*
+          rsync --ignore-missing-args -zavpm --no-l \
+          --exclude='cats.mdx' \
+          --exclude='infrastructure/ansible/systests/*' \
+          --include='*.docnav.json' \
+          --include='*.apidocs.json' \
+          --include='*.mdx' \
+          --include='*.png' \
+          --include='*.gif' \
+          --include='*.jpg' \
+          --include='*.svg' \
+          --include='*.jpeg' \
+          --include='*.webp' \
+          --include='*.devdocs.json' \
+          --include='*/' \
+          --exclude='*' \
+          ${{ github.workspace }}/tmp/ \
+          ${{ github.workspace }}/${{ inputs.prebuild }}/${{ github.event.repository.name }}/
+
+      - name: Tidy before Vercel CLI run
+        if: github.event.pull_request.merged != true && github.event.pull_request.closed != true
+        shell: bash
+        run: |
+            mkdir ${{ github.workspace }}/build/ 
+            mv ${{ github.workspace }}/${{ inputs.prebuild }} ${{ github.workspace }}/build/
+            mv ${{ github.workspace }}/${{ inputs.repo }} ${{ github.workspace }}/build/
+
+      - name: Generate preview
+        if: github.event.pull_request.merged != true && github.event.pull_request.closed != true
+        id: vercel-deploy
+        uses: elastic/builder@v21.5.0
+        continue-on-error: false
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_STAGING_PREVIEW_DOCS }} #Required
+          vercel-project-name: ${{ inputs.project-name }}
+          working-directory: ${{ github.workspace }}/build/
+          github-token: ${{ secrets.VERCEL_GITHUB_TOKEN }} #Optional 
+          github-comment: true # Otherwise need github-token (VERCEL_GITHUB_TOKEN)
+
+      - name: Portal for deploy
+        if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/${{ inputs.prebuild }}
+          git config user.name count-docula
+          git config user.email github-actions@github.com
+          git pull
+          git add .
+          git commit -m "New content from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          git push https://${{ secrets.VERCEL_GITHUB_TOKEN }}@github.com/elastic/${{ inputs.prebuild }}

--- a/.github/workflows/docs-elastic-staging-publish.yml
+++ b/.github/workflows/docs-elastic-staging-publish.yml
@@ -53,7 +53,7 @@ jobs:
           path: 'tmp'
           persist-credentials: false
 
-      - name: Checkout dev doc docsmobile app
+      - name: Checkout staging site repo
         uses: actions/checkout@v3.0.1
         with:
           repository: elastic/${{ inputs.repo }}

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ jobs:
 
 Change values as needed.
 
-
 Install as `.github/workflows/staging-docs-builder.yml` in content source.
 
 :wave: Provide the content source access to the Vercel_ tokens.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ jobs:
 
 Change values as needed.
 
-For example, if you do not have a docs dir, use the correct dir or no dir instead.
 
 Install as `.github/workflows/staging-docs-builder.yml` in content source.
 

--- a/README.md
+++ b/README.md
@@ -122,3 +122,48 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO }}
 ```
+
+
+### Staging docs builder, calling workflow
+
+Change values as needed.
+
+For example, if you do not have a docs dir, use the correct dir or no dir instead.
+
+Install as `.github/workflows/staging-docs-builder.yml` in content source.
+
+:wave: Provide the content source access to the Vercel_ tokens.
+
+```yml
+name: Elastic docs
+
+on:
+  pull_request_target:
+    paths:
+    # Change docs dir to your repos docs dir
+      - '**.mdx'
+      - '**.docnav.json'
+      - '**.docapi.json'
+      - '**.devdocs.json'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.svg'
+      - '**.png'
+      - '**.gif'
+    types: [closed, opened, synchronize]
+
+jobs:
+  publish:
+    uses: elastic/workflows/.github/workflows/docs-elastic-staging-publish.yml@main
+    with:
+      # Refers to Vercel project
+      project-name: docsstaging-elastic-dev
+      # Which prebuild step (dev or not)
+      prebuild: wordlake-staging
+      # Docsmobile project dir
+      repo: docsstaging.elastic.dev
+    secrets:
+      VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_STAGING }}


### PR DESCRIPTION
In pursuit of https://github.com/elastic/docsmobile/issues/378

I have a TODO to update the README to remove the project names and secrets from the template code after we remove the required attribute and hard-code the name in the workflows. 