### PR TITLE
Update docs-elastic-dev-publish.yml

### DIFF
--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -73,6 +73,7 @@ jobs:
         run: cp -f ${{ github.workspace }}/wordlake-dev/.scaffold/content.js ${{ github.workspace }}/docs.elastic.dev/config/.
 
       - name: Portal
+        if: github.event.action != 'closed' || github.event.pull_request.merged == true
         shell: bash
         run: |
           mkdir -p ${{ github.workspace }}/${{ inputs.prebuild }}/${{ github.event.repository.name }}


### PR DESCRIPTION
Fix issue where closed PRs were triggering builds.

Related to https://github.com/elastic/workflows/pull/19

Verified that the change for .co passes on [closed PRs](https://github.com/elastic/search-ui/actions/runs/4692844735).