### PR TITLE
Update README.md to account for workflow changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ name: Dev Docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir (optional)
+    # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -91,7 +91,7 @@ name: Elastic docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir (optional)
+    # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -122,7 +122,7 @@ name: Elastic docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir (optional)
+    # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -160,7 +160,7 @@ name: Elastic docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir (optional)
+    # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -190,7 +190,7 @@ name: Elastic docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir (optional)
+    # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ We also use a different set of secrets that we have to provide the content sourc
 
 Change values as needed.
 
-For example, if you do not have a docs dir, use the correct dir or no dir instead.
-
 Install as `.github/workflows/dev-docs-builder.yml` in the content source.
 
 :wave: Provide the content source access to the Vercel_ tokens.
@@ -78,8 +76,6 @@ jobs:
 ### Public docs builder, calling workflow
 
 Change values as needed.
-
-For example, if you do not have a docs dir, use the correct dir or no dir instead.
 
 Install as `.github/workflows/co-docs-builder.yml` in content source.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are two contexts, internal & external docs.
 
 Each pairs with a "separate" web app.
 
-The webapps are built by Vercel, and as a result we get 2x "prod" instances.
+The web apps are built by Vercel, and as a result we get 2x "prod" instances.
 
 Before prod is built in each instance, we need to:
 
@@ -31,6 +31,10 @@ After token access, new PRs will trigger the Action.
 
 ⚠️ Merging to main will not trigger a build.
 
+Public repos require an extra level of security and we require that a `ci:doc-build` label be added by a repo maintainer.
+
+We also use a different set of secrets that we have to provide the content source access to the Vercel tokens for. For internal and private repos, the token access is automatically provided. 
+
 ### Dev docs builder, calling workflow
 
 Change values as needed.
@@ -47,7 +51,7 @@ name: Dev Docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir
+    # Change docs dir to your repos docs dir (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -63,13 +67,6 @@ jobs:
   publish:
     name: Vercel Build Check
     uses: elastic/workflows/.github/workflows/docs-elastic-dev-publish.yml@main
-    with:
-      # Refers to Vercel project
-      project-name: docs-elastic-dev
-      # Which prebuild step (dev or not)
-      prebuild: wordlake-dev
-      # Docsmobile project dir
-      repo: docs.elastic.dev
     secrets:
       VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -86,7 +83,7 @@ For example, if you do not have a docs dir, use the correct dir or no dir instea
 
 Install as `.github/workflows/co-docs-builder.yml` in content source.
 
-:wave: Provide the content source access to the Vercel_ tokens.
+#### Private repos
 
 ```yml
 name: Elastic docs
@@ -94,7 +91,7 @@ name: Elastic docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir
+    # Change docs dir to your repos docs dir (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -110,16 +107,41 @@ jobs:
   publish:
     uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
     with:
-      # Refers to Vercel project
-      project-name: docs-elastic-co
-      # Which prebuild step (dev or not)
-      prebuild: wordlake
-      # Docsmobile project dir
-      repo: docs.elastic.co
     secrets:
       VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO }}
+```
+
+#### Public repos
+
+```yml
+name: Elastic docs
+
+on:
+  pull_request_target:
+    paths:
+    # Change docs dir to your repos docs dir (optional)
+      - '**.mdx'
+      - '**.docnav.json'
+      - '**.docapi.json'
+      - '**.devdocs.json'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.svg'
+      - '**.png'
+      - '**.gif'
+    types: [closed, opened, synchronize, labeled]
+
+jobs:
+  publish:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:doc-build')
+    uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
+    secrets:
+      VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN_PUBLIC }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PUBLIC }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PUBLIC }}
       VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO }}
 ```
 
@@ -130,7 +152,7 @@ Change values as needed.
 
 Install as `.github/workflows/staging-docs-builder.yml` in content source.
 
-:wave: Provide the content source access to the Vercel_ tokens.
+#### Private repos
 
 ```yml
 name: Elastic docs
@@ -138,7 +160,7 @@ name: Elastic docs
 on:
   pull_request_target:
     paths:
-    # Change docs dir to your repos docs dir
+    # Change docs dir to your repos docs dir (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -153,15 +175,40 @@ on:
 jobs:
   publish:
     uses: elastic/workflows/.github/workflows/docs-elastic-staging-publish.yml@main
-    with:
-      # Refers to Vercel project
-      project-name: docs-staging-elastic-dev
-      # Which prebuild step (dev or not)
-      prebuild: wordlake-staging
-      # Docsmobile project dir
-      repo: docs-staging.elastic.dev
     secrets:
       VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_STAGING }}
+```
+
+#### Public repos
+
+```yml
+name: Elastic docs
+
+on:
+  pull_request_target:
+    paths:
+    # Change docs dir to your repos docs dir (optional)
+      - '**.mdx'
+      - '**.docnav.json'
+      - '**.docapi.json'
+      - '**.devdocs.json'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.svg'
+      - '**.png'
+      - '**.gif'
+    types: [closed, opened, synchronize, labeled]
+
+jobs:
+  publish:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:doc-build')
+    uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
+    secrets:
+      VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN_PUBLIC }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PUBLIC }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PUBLIC }}
+      VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO }}
+```

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ name: Dev Docs
 
 on:
   pull_request_target:
+    # The paths property can be omitted entirely if the repo is mainly used for docs. Leaving it in can result in builds that 
+    # have branch protection checks in place lose the ability to merge because the workflow is not starting. If this property 
+    # is included, please ensure that branch protection checks are disabled for the repo. 
     paths:
-    # Preface with your docs dir if you need further specificity (optional)
+      # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -86,8 +89,11 @@ name: Elastic docs
 
 on:
   pull_request_target:
+    # The paths property can be omitted entirely if the repo is mainly used for docs. Leaving it in can result in builds that 
+    # have branch protection checks in place lose the ability to merge because the workflow is not starting. If this property 
+    # is included, please ensure that branch protection checks are disabled for the repo. 
     paths:
-    # Preface with your docs dir if you need further specificity (optional)
+      # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -117,8 +123,11 @@ name: Elastic docs
 
 on:
   pull_request_target:
+    # The paths property can be omitted entirely if the repo is mainly used for docs. Leaving it in can result in builds that 
+    # have branch protection checks in place lose the ability to merge because the workflow is not starting. If this property 
+    # is included, please ensure that branch protection checks are disabled for the repo. 
     paths:
-    # Preface with your docs dir if you need further specificity (optional)
+      # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -155,8 +164,11 @@ name: Elastic docs
 
 on:
   pull_request_target:
+    # The paths property can be omitted entirely if the repo is mainly used for docs. Leaving it in can result in builds that 
+    # have branch protection checks in place lose the ability to merge because the workflow is not starting. If this property 
+    # is included, please ensure that branch protection checks are disabled for the repo. 
     paths:
-    # Preface with your docs dir if you need further specificity (optional)
+      # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'
@@ -185,8 +197,11 @@ name: Elastic docs
 
 on:
   pull_request_target:
+    # The paths property can be omitted entirely if the repo is mainly used for docs. Leaving it in can result in builds that 
+    # have branch protection checks in place lose the ability to merge because the workflow is not starting. If this property 
+    # is included, please ensure that branch protection checks are disabled for the repo. 
     paths:
-    # Preface with your docs dir if you need further specificity (optional)
+      # Preface with your docs dir if you need further specificity (optional)
       - '**.mdx'
       - '**.docnav.json'
       - '**.docapi.json'


### PR DESCRIPTION
In pursuit of https://github.com/elastic/docsmobile/issues/457

Updates the README.md to account for workflow changes to not include the `inputs` and also to account for public repos and the differences in the workflow content for those. 