### PR TITLE
Update docs-elastic-dev-publish.yml to use project ID fallback

### DIFF
--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -110,8 +110,8 @@ jobs:
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_DEV_PREVIEW_DOCS || secrets.VERCEL_PROJECT_ID_DOCS_DEV }} #Required
-          vercel-project-name: ${{ inputs.project-name || 'dev-preview-docs' }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_DOCS_DEV || secrets.VERCEL_PROJECT_ID_DEV_PREVIEW_DOCS }} #Fallback in place for migration
+          vercel-project-name: ${{ inputs.project-name || 'dev-preview-docs' }} #Fallback in place for migration
           working-directory: ${{ github.workspace }}/build/
           github-token: ${{ secrets.VERCEL_GITHUB_TOKEN }} #Optional 
           github-comment: true # Otherwise need github-token (VERCEL_GITHUB_TOKEN)

--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -111,7 +111,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_DEV_PREVIEW_DOCS || secrets.VERCEL_PROJECT_ID_DOCS_DEV }} #Required
-          vercel-project-name: docs-elastic-dev # To be changed after renaming in Vercel
+          vercel-project-name: ${{ inputs.project-name || 'dev-preview-docs' }}
           working-directory: ${{ github.workspace }}/build/
           github-token: ${{ secrets.VERCEL_GITHUB_TOKEN }} #Optional 
           github-comment: true # Otherwise need github-token (VERCEL_GITHUB_TOKEN)

--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_DEV_PREVIEW_DOCS }} #Required
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_DEV_PREVIEW_DOCS || secrets.VERCEL_PROJECT_ID_DOCS_DEV }} #Required
           vercel-project-name: docs-elastic-dev # To be changed after renaming in Vercel
           working-directory: ${{ github.workspace }}/build/
           github-token: ${{ secrets.VERCEL_GITHUB_TOKEN }} #Optional 


### PR DESCRIPTION
We have an issue where the builds [fail](https://elastic.slack.com/archives/C02762N267P/p1682346359491249) due to [updating](https://github.com/elastic/workflows/pull/21) the builders. 

This PR attempts to circumvent the issue in the interim when the migration to the new names is taking place by having the original values for project-name and project-id as fallbacks.