### PR TITLE
Remove `with:` from snippet in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ on:
 jobs:
   publish:
     uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
-    with:
     secrets:
       VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Removes `with:` from public docs builder snippet. @glitteringkatie and I got an error when running the workflow with the `with:` included.  