### PR TITLE
Update docs-elastic-dev-publish.yml to change fallback order

### DIFF
--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_DOCS_DEV || secrets.VERCEL_PROJECT_ID_DEV_PREVIEW_DOCS }} #Fallback in place for migration
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_DEV_PREVIEW_DOCS || secrets.VERCEL_PROJECT_ID_DOCS_DEV }} #Fallback in place for migration
           vercel-project-name: ${{ inputs.project-name || 'dev-preview-docs' }} #Fallback in place for migration
           working-directory: ${{ github.workspace }}/build/
           github-token: ${{ secrets.VERCEL_GITHUB_TOKEN }} #Optional 


### PR DESCRIPTION
This PR changes the fallback order in place for the `vercel-project-id`. We've had issues where changing the variables that are sent from the consuming actions trigger a second build that fails after merging. My assumption is that because the `VERCEL_PROJECT_ID_DOCS_DEV` is shared across all repos that the fallback is not working properly. 

Will test and revert if any new issues arise.