### PR TITLE
Update docs-elastic-co-publish.yml to include svgs

### DIFF
--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -86,6 +86,7 @@ jobs:
           --include='*.png' \
           --include='*.gif' \
           --include='*.jpg' \
+          --include='*.svg' \
           --include='*.jpeg' \
           --include='*.webp' \
           --include='*.devdocs.json' \


### PR DESCRIPTION
Was resulting in [broken builds](https://vercel.com/elastic-dev/co-preview-docs/2aenbZ8SqaDzXZp9854oJ7eTbgK5) that included SVGs