### PR TITLE
deps: bump `actions/checkout` to v4

### DIFF
--- a/.github/workflows/dev-docs-builder.yml
+++ b/.github/workflows/dev-docs-builder.yml
@@ -33,13 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup workspace
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout current branch into temp
         if: github.event.pull_request.merged == false
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 'temp'
           fetch-depth: 2
@@ -48,13 +48,13 @@ jobs:
 
       - name: Checkout current branch into temp
         if: github.event.pull_request.merged == true
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 'temp'
           persist-credentials: false
 
       - name: Checkout essential repos
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs.elastic.dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout Wordlake
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake-dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}

--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -30,13 +30,13 @@ jobs:
     steps:
 
       - name: Setup workspace
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout branch into tmp
         if: github.event.action != 'closed' && github.event.pull_request.merged != true
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
@@ -45,13 +45,13 @@ jobs:
 
       - name: Prepare content for deploy
         if: ${{ github.event.pull_request.merged }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           persist-credentials: false
 
       - name: Checkout essential repos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs.elastic.co
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout Wordlake
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}

--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -31,13 +31,13 @@ jobs:
     steps:
 
       - name: Setup workspace
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout branch into temp
         if: github.event.action != 'closed' && github.event.pull_request.merged != true
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
@@ -46,13 +46,13 @@ jobs:
 
       - name: Prepare content for deploy
         if: ${{ github.event.pull_request.merged }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           persist-credentials: false
 
       - name: Checkout dev doc docsmobile app
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs.elastic.dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout Wordlake
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake-dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}

--- a/.github/workflows/docs-elastic-staging-publish.yml
+++ b/.github/workflows/docs-elastic-staging-publish.yml
@@ -23,13 +23,13 @@ jobs:
     steps:
 
       - name: Setup workspace
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout branch into temp
         if: github.event.action != 'closed' && github.event.pull_request.merged != true
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
@@ -38,13 +38,13 @@ jobs:
 
       - name: Prepare content for deploy
         if: ${{ github.event.pull_request.merged }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           persist-credentials: false
 
       - name: Checkout essential repos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs-staging.elastic.dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout Wordlake-staging
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake-staging
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}

--- a/.github/workflows/docs-publish-co.yml
+++ b/.github/workflows/docs-publish-co.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup workspace
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -70,7 +70,7 @@ jobs:
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.action != 'closed' &&
           github.event.pull_request.merged != true
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
@@ -81,14 +81,14 @@ jobs:
         if: |
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.pull_request.merged
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           persist-credentials: false
 
       - name: Checkout essential repos
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs.elastic.co
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: Checkout Wordlake
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}

--- a/.github/workflows/docs-publish-dev-testing-builder.yml
+++ b/.github/workflows/docs-publish-dev-testing-builder.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Setup workspace
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -71,7 +71,7 @@ jobs:
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.action != 'closed' &&
           github.event.pull_request.merged != true
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
@@ -82,14 +82,14 @@ jobs:
         if: |
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.pull_request.merged
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           persist-credentials: false
 
       - name: Checkout dev doc docsmobile app
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs.elastic.dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Checkout Wordlake
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake-dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}

--- a/.github/workflows/docs-publish-dev.yml
+++ b/.github/workflows/docs-publish-dev.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Setup workspace
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -71,7 +71,7 @@ jobs:
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.action != 'closed' &&
           github.event.pull_request.merged != true
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
@@ -82,14 +82,14 @@ jobs:
         if: |
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.pull_request.merged
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           persist-credentials: false
 
       - name: Checkout dev doc docsmobile app
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs.elastic.dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Checkout Wordlake
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake-dev
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}

--- a/.github/workflows/docs-publish-staging.yml
+++ b/.github/workflows/docs-publish-staging.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup workspace
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -63,7 +63,7 @@ jobs:
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.action != 'closed' &&
           github.event.pull_request.merged != true
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
@@ -74,14 +74,14 @@ jobs:
         if: |
           needs.check_file_type_changes.outputs.changed_files &&
           github.event.pull_request.merged
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'tmp'
           persist-credentials: false
 
       - name: Checkout essential repos
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/docs.elastic.co
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Checkout Wordlake-staging
         if: ${{ needs.check_file_type_changes.outputs.changed_files }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: elastic/wordlake-staging
           token: ${{ secrets.VERCEL_GITHUB_TOKEN }}


### PR DESCRIPTION
As the previous versions are running deprecated/end-of-life Node
versions.
