### PR TITLE
Document the `subdirectory` input

### DIFF
--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -9,6 +9,17 @@ on:
         type: string
       repo: 
         type: string
+      #
+      # Pass a `subdirectory` to this workflow from a content repo if you
+      # only want to grab files from a specific subdirectory in the
+      # content repo. If you do not specify a `subdirectoy`, the workflow
+      # will grab all relevant files from the entire repo.
+      #
+      # IMPORTANT: Always include a trailing slash when defining a
+      # subdirectory. For example:
+      #   with:
+      #     subdirectory: 'docs/en/serverless/'
+      #
       subdirectory:
         type: string
         default: ''

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ jobs:
 
 Change values as needed.
 
+You can optionally pass a `subdirectory` to this workflow from a content repo if you only want to grab files from a specific subdirectory in the content repo. If you do not specify a `subdirectoy`, the workflow will grab all relevant files from the entire repo.
+
+>[!IMPORTANT]
+>Always include a trailing slash when defining a `subdirectory`. For example:
+>```
+>  with:
+>    subdirectory: 'docs/en/serverless/'
+>```
+
 Install as `.github/workflows/co-docs-builder.yml` in content source.
 
 #### Private repos


### PR DESCRIPTION
Adds a code comment explaining what the `subdirectory` input is and how to use it. This should also be added to the dev docs, but this is at least a start. Suggestions are very welcome.