### PR TITLE
Apply messy band-aid to builder

### DIFF
--- a/.github/workflows/docs-elastic-co-publish.yml
+++ b/.github/workflows/docs-elastic-co-publish.yml
@@ -76,8 +76,8 @@ jobs:
         shell: bash
         run: cp -f ${{ github.workspace }}/wordlake/.scaffold/content.js ${{ github.workspace }}/docs.elastic.co/config/. 
 
-      - name: Portal
-        if: github.event.action != 'closed' || github.event.pull_request.merged == true
+      - name: Portal (subdirectory)
+        if: (inputs.subdirectory != '') && (github.event.action != 'closed' || github.event.pull_request.merged == true)
         shell: bash
         run: |
           mkdir -p ${{ github.workspace }}/wordlake/${{ github.event.repository.name }}
@@ -94,6 +94,28 @@ jobs:
           --include='${{ inputs.subdirectory }}**.webp' \
           --include='${{ inputs.subdirectory }}**.devdocs.json' \
           --include='${{ inputs.subdirectory }}*/' \
+          --exclude='*' \
+          ${{ github.workspace }}/tmp/ \
+          ${{ github.workspace }}/wordlake/${{ github.event.repository.name }}/
+
+      - name: Portal (root)
+        if: (inputs.subdirectory == '') && (github.event.action != 'closed' || github.event.pull_request.merged == true)
+        shell: bash
+        run: |
+          mkdir -p ${{ github.workspace }}/wordlake/${{ github.event.repository.name }}
+          rm -rf ${{ github.workspace }}/wordlake/${{ github.event.repository.name }}/*
+          rsync --ignore-missing-args -zavpm --no-l \
+          --include='*.docnav.json' \
+          --include='*.apidocs.json' \
+          --include='*.mdx' \
+          --include='*.png' \
+          --include='*.gif' \
+          --include='*.jpg' \
+          --include='*.svg' \
+          --include='*.jpeg' \
+          --include='*.webp' \
+          --include='*.devdocs.json' \
+          --include='*/' \
           --exclude='*' \
           ${{ github.workspace }}/tmp/ \
           ${{ github.workspace }}/wordlake/${{ github.event.repository.name }}/


### PR DESCRIPTION
This is not ideal but we can’t find a better way for now and need to get unblocked.

The issue is that the Portal step (called `Portal (subdirectory)`) in the. Doesn't work when the `inputs.subdirectory` is an empty string, or any other reasonable default. We tried `/`, `./`, and `*/`.