### PR TITLE
ci: support the merge_queue event

### DIFF
--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -35,13 +35,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Get ref
+        id: get_ref
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let ref = `${{ github.event.merge_group.head_ref }}`;
+            if (!ref) {
+              ref = `refs/pull/${{ github.event.number }}/head`
+            }
+            core.setOutput('ref', ref);
+
       - name: Checkout branch into temp
         if: github.event.action != 'closed' && github.event.pull_request.merged != true
         uses: actions/checkout@v4
         with:
           path: 'tmp'
           fetch-depth: 2
-          ref: refs/pull/${{ github.event.number }}/head
+          ref: ${{ steps.get_ref.outputs.ref }}
           persist-credentials: false
 
       - name: Prepare content for deploy


### PR DESCRIPTION
This should help with support the `merge_group` event:
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group

That event is the one for the GitHub Merge Queue, https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

As far as I see, the checkout does not support the `merge_queue.ref` format, see the payload below:

```json
{
  "action": "checks_requested",
  "merge_group": {
    "head_sha": "0a2fafe1970c4388751f4d0e5006c8fa28fa09c0",
    "head_ref": "refs/heads/gh-readonly-queue/main/pr-1314-6e988a533b1f295d9693def9d9ba1c9e8f97a261",
    "base_sha": "6e988a533b1f295d9693def9d9ba1c9e8f97a261",
    "base_ref": "refs/heads/main",
    "head_commit": {
      "id": "0a2fafe1970c4388751f4d0e5006c8fa28fa09c0",
      "tree_id": "7db34998a911cf9dc27c40ec4825bf10e0e3c930",
      "message": "github-actions: support merge-queue for the mandatory GH checks (#1314)\n\nSee https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows\\#merge_group",
      "timestamp": "2024-11-18T14:54:24Z",
      "author": {
        "name": "Victor Martinez",
...
    }
```
