### PR TITLE
Exclude Kibana docs that aren't meant for docsmobile.

### DIFF
--- a/.github/workflows/docs-elastic-dev-publish.yml
+++ b/.github/workflows/docs-elastic-dev-publish.yml
@@ -90,6 +90,7 @@ jobs:
           rsync --ignore-missing-args -zavpm --no-l \
           --exclude='cats.mdx' \
           --exclude='infrastructure/ansible/systests/*' \
+          --exclude='*.kibana.dev/*' \
           --include='*.docnav.json' \
           --include='*.apidocs.json' \
           --include='*.mdx' \


### PR DESCRIPTION
Kibana has some mdx docs content that isn't meant for publishing on docsmobile and therefore causes builds to fail. This PR updates the dev docs workflow to exclude any docs that live in a designated `*.kibana.dev` directory.

Please let me know if this isn't the right place for this update, or if I should implement it in another way. I'd imagine that ideally this would be configurable via a workflow call input, but that would involve making more significant changes and I want to be careful not to break things for others. I saw that `infrastructure/ansible/systests/*` was excluded in the workflow, and took that as a sign that we could follow this approach to exclude other special directories too.

Note that I've only updated a single workflow here (the only one we use). If there are others I should change for consistency, please let me know.