### PR TITLE
Fix: createCaseTool owner should be securitySolution, not observability

### DIFF
--- a/workflows/security/response/createcasetool.yaml
+++ b/workflows/security/response/createcasetool.yaml
@@ -2,27 +2,20 @@
 # Workflow: createCaseTool
 # Category: security/response
 #
-# The `createCaseTool` workflow allows an agent to manually create a case
-# with a specified title and description. It is enabled and categorized under
-# "Observability" and "AgentTool" tags. The workflow includes a single step
-# that utilizes the Kibana API to create a case in the default space, with
-# settings that specify high severity and automatic tagging.
+# Creates a new case using the Kibana Cases API. Supports configurable
+# severity and creates cases under the Security Solution owner so they
+# appear in Security > Cases rather than Observability.
 #
 # Author: Elastic
 # Created: 2025-11-19
-# Tags: Observability, AgentTool
+# Tags: Security, AgentTool
 # =============================================================================
 name: createCaseTool
-description: A tool that let an Agent to create a case
+description: A tool that lets an Agent create a Security case
 enabled: true
 
 # ---------------------------------------------------------------------------
 # TRIGGERS
-# ---------------------------------------------------------------------------
-# Defines how and when this workflow is executed. Supported trigger types:
-#   - manual: Run on-demand from the Kibana UI or API
-#   - scheduled: Run on a recurring schedule (every: "5m" or rrule)
-#   - alert: Run automatically when a security alert is triggered
 # ---------------------------------------------------------------------------
 triggers:
   - type: manual
@@ -30,33 +23,27 @@ triggers:
 # ---------------------------------------------------------------------------
 # TAGS
 # ---------------------------------------------------------------------------
-# Categories and labels for organizing, filtering, and discovering workflows
-# in the Kibana UI. Tags help with:
-#   - Categorizing workflows by use case (security, observability, etc.)
-#   - Filtering in the workflow library
-#   - Grouping related workflows together
+tags: ["Security", "AgentTool"]
+
 # ---------------------------------------------------------------------------
-tags: ["Observability", "AgentTool"]
+# INPUTS
+# ---------------------------------------------------------------------------
 inputs:
   - name: caseDescription
     required: true
     type: string
+    description: "Detailed description of the incident or investigation"
   - name: caseTitle
     required: true
     type: string
-
+    description: "Title for the case"
+  - name: severity
+    type: string
+    description: "Case severity: low, medium, high, critical"
+    default: "medium"
 
 # ---------------------------------------------------------------------------
 # STEPS
-# ---------------------------------------------------------------------------
-# The sequence of actions this workflow performs. Each step executes an
-# action and can reference outputs from previous steps. Key properties:
-#   - name: Unique identifier for referencing this step's output
-#   - type: The action to perform (http, elasticsearch.search, foreach, etc.)
-#   - with: Parameters passed to the action
-#   - condition: Optional expression to conditionally run the step
-#   - on-failure: Error handling configuration (retry, continue, etc.)
-# Access step outputs using {{ steps.step_name.output.field }} syntax
 # ---------------------------------------------------------------------------
 steps:
 
@@ -64,14 +51,10 @@ steps:
   # STEP 1: kibana_createCaseDefaultSpace_step
   # -------------------------------------------------------------------------
   # Creates a new case using the Kibana Cases API (POST /api/cases).
-  # Cases provide a workspace for investigating and tracking security
-  # incidents.
-  # Required: title, description, owner (e.g., "securitySolution"), tags,
-  # severity.
-  # Output: {{ steps.kibana_createCaseDefaultSpace_step.output.id }} contains
-  # the new case ID.
-  # Liquid syntax used:
-  # - References workflow input parameter(s)
+  # Owner is set to "securitySolution" so cases appear under
+  # Security > Cases in Kibana, not the Observability cases view.
+  # Severity is configurable via the severity input (defaults to medium).
+  # Output: {{ steps.kibana_createCaseDefaultSpace_step.output.id }}
   # -------------------------------------------------------------------------
   - name: kibana_createCaseDefaultSpace_step
     type: kibana.createCaseDefaultSpace
@@ -82,11 +65,11 @@ steps:
         name: none
         type: .none
       description: |
-        "{{ inputs.caseDescription }}"
-      owner: observability
+        {{ inputs.caseDescription }}
+      owner: securitySolution
       settings:
-        syncAlerts: false
-      severity: high
+        syncAlerts: true
+      severity: "{{ inputs.severity }}"
       tags:
         - Automatic
       title: "{{ inputs.caseTitle }}"


### PR DESCRIPTION
The createCaseTool workflow is categorised under security/response but creates cases with owner: observability, causing them to appear in Observability > Cases instead of Security > Cases in Kibana.

Changes:
- owner: observability -> owner: securitySolution
- Added severity input (defaults to "medium") instead of hardcoded "high"
- Added syncAlerts: true for security case alert linking
- Updated tags from "Observability" to "Security"
- Removed extra quotes around description Liquid expression
- Added input descriptions