### PR TITLE
[Library] Initial directory bootstrap and templates sample

### DIFF
--- a/library/categories.yaml
+++ b/library/categories.yaml
@@ -1,0 +1,61 @@
+# Workflow Template Library — categories vocabulary
+#
+# Single source of truth for the closed-vocabulary `categories: [...]` field
+# on every template's `template-metadata` block. The publish CI parses this
+# file and rejects any template whose `categories` entries are not declared
+# here.
+#
+# Adding a new category is a PR that adds an entry below. Categories are
+# orthogonal to solutions: a `notification` template can serve any solution;
+# a `monitoring` template can be security- or observability-flavored. Do
+# not couple category IDs to specific solutions.
+
+categories:
+  - id: enrichment
+    name: "Enrichment"
+    description: "Augment data with external intelligence."
+  - id: detection
+    name: "Detection"
+    description: "Identify threats, anomalies, or events of interest."
+  - id: response
+    name: "Response"
+    description: "Take action on incidents (acknowledge, close, escalate, isolate)."
+  - id: hunting
+    name: "Hunting"
+    description: "Proactively search for indicators of compromise or anomalies."
+  - id: threat-intel
+    name: "Threat intelligence"
+    description: "Indicators, attribution, reputation, threat actor context."
+  - id: notification
+    name: "Notification"
+    description: "Send messages to people or channels (Slack, Teams, email, paging)."
+  - id: case-management
+    name: "Case management"
+    description: "Create, update, or enrich cases / incidents / tickets."
+  - id: monitoring
+    name: "Monitoring"
+    description: "Health, status, and threshold-based observation."
+  - id: root-cause-analysis
+    name: "Root cause analysis"
+    description: "Investigate the underlying cause of an incident or anomaly."
+  - id: data-ingestion
+    name: "Data ingestion"
+    description: "Bring data into Elasticsearch from external systems."
+  - id: data-transformation
+    name: "Data transformation"
+    description: "Reshape, filter, or enrich data in place."
+  - id: reporting
+    name: "Reporting"
+    description: "Scheduled summaries, exports, or recurring digests."
+  - id: search
+    name: "Search"
+    description: "ES|QL, semantic search, knowledge retrieval workflows."
+  - id: ai-agent
+    name: "AI agent"
+    description: "Agentic workflows, LLM-driven automation, tool calling."
+  - id: integration
+    name: "Integration"
+    description: "Connect Elastic with external systems (CI, ITSM, comms)."
+  - id: utility
+    name: "Utility"
+    description: "Reusable helpers, demos, and getting-started workflows."

--- a/library/workflows/create-slack-channel/create-slack-channel.yaml
+++ b/library/workflows/create-slack-channel/create-slack-channel.yaml
@@ -1,0 +1,53 @@
+template-metadata:
+  slug: create-slack-channel
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "Create Slack Channel"
+  description: >-
+    Create a new Slack channel (public or private) via the Slack v2 API.
+    Useful as a building block for incident-response workflows that spin
+    up a dedicated war-room channel per case or alert.
+  category: automation
+  tags: [slack, channel, automation, integration]
+  icon: slack
+  install:
+    form:
+      - name: slack-connector
+        label: "Slack (v2) connector"
+        description: >-
+          The Slack (v2) connector used to create the channel. If you
+          don't have one yet, click "Create new" and configure it with a
+          Slack bot token that has the `channels:manage` and
+          `groups:write` scopes.
+        inputType: connector
+        connectorType: .slack2
+        required: true
+
+name: Create Slack Channel
+description: Create a new Slack channel via the Slack v2 API.
+
+triggers:
+  - type: manual
+    inputs:
+      - name: channel_name
+        type: string
+        description: >-
+          Name of the channel to create. Lowercase letters, numbers,
+          hyphens, and underscores only; 80 characters or fewer.
+        required: true
+      - name: is_private
+        type: boolean
+        description: >-
+          Whether to create a private channel. Defaults to false (public).
+        required: false
+        default: false
+
+steps:
+  # Create the channel via the dedicated Slack v2 step type. The bot
+  # token lives in the connector configuration.
+  - name: create_channel
+    type: slack2.createConversation
+    connector-id: __install__.slack-connector
+    with:
+      name: "{{ inputs.channel_name }}"
+      isPrivate: "{{ inputs.is_private }}"

--- a/library/workflows/create-slack-channel/create-slack-channel.yaml
+++ b/library/workflows/create-slack-channel/create-slack-channel.yaml
@@ -7,8 +7,7 @@ template-metadata:
     Create a new Slack channel (public or private) via the Slack v2 API.
     Useful as a building block for incident-response workflows that spin
     up a dedicated war-room channel per case or alert.
-  category: automation
-  tags: [slack, channel, automation, integration]
+  categories: [integration]
   icon: slack
   install:
     form:

--- a/library/workflows/hash-threat-check/hash-threat-check.yaml
+++ b/library/workflows/hash-threat-check/hash-threat-check.yaml
@@ -1,0 +1,93 @@
+template-metadata:
+  slug: hash-threat-check
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "Hash Threat Check (VirusTotal)"
+  description: >-
+    Check a file hash (MD5, SHA-1, or SHA-256) against the VirusTotal
+    database and produce a human-readable threat report covering file
+    metadata, AV detection counts, community reputation, and an overall
+    threat verdict.
+  solutions: [security]
+  category: detection
+  tags: [detection, threat-intel, virustotal, hash, malware]
+  icon: virustotal
+  install:
+    form:
+      - name: virustotal-connector
+        label: "VirusTotal connector"
+        description: >-
+          The VirusTotal connector used to look up the file hash. If you
+          don't have one yet, click "Create new" and configure it with
+          your VirusTotal API key (https://www.virustotal.com/gui/my-apikey).
+        inputType: connector
+        connectorType: .virustotal
+        required: true
+
+name: Hash Threat Check
+description: Check file hashes (MD5, SHA-1, SHA-256) against VirusTotal for malware detection.
+
+triggers:
+  - type: manual
+    inputs:
+      - name: file_hash
+        type: string
+        description: >-
+          The file hash to check (MD5, SHA-1, or SHA-256 format) for malware
+          and threat intelligence.
+        required: true
+
+steps:
+  # Query VirusTotal via the dedicated step type. The API key lives in the
+  # connector configuration, so no credential appears in this YAML.
+  - name: lookup_file_hash
+    type: virustotal.scanFileHash
+    connector-id: __install__.virustotal-connector
+    with:
+      hash: "{{ inputs.file_hash }}"
+    on-failure:
+      retry:
+        max-attempts: 2
+        delay: 3s
+      continue: true
+
+  # Format and emit a human-readable report to the workflow execution logs.
+  - name: format_results
+    type: console
+    with:
+      message: |
+        === File Hash Threat Analysis Report ===
+        File Hash: {{ inputs.file_hash }}
+
+        VirusTotal Analysis:
+        - File Name: {{ steps.lookup_file_hash.output.attributes.meaningful_name }}
+        - File Type: {{ steps.lookup_file_hash.output.attributes.type_description }}
+        - File Size: {{ steps.lookup_file_hash.output.attributes.size }} bytes
+        - First Seen: {{ steps.lookup_file_hash.output.attributes.first_submission_date }}
+        - Last Analysis: {{ steps.lookup_file_hash.output.attributes.last_analysis_date }}
+
+        Detection Results:
+        - Malicious Detections: {{ steps.lookup_file_hash.output.stats.malicious }}
+        - Suspicious Detections: {{ steps.lookup_file_hash.output.stats.suspicious }}
+        - Undetected: {{ steps.lookup_file_hash.output.stats.undetected }}
+        - Total Scans: {{ steps.lookup_file_hash.output.stats.malicious | plus: steps.lookup_file_hash.output.stats.suspicious | plus: steps.lookup_file_hash.output.stats.undetected }}
+
+        File Hashes (Cross-reference):
+        - MD5: {{ steps.lookup_file_hash.output.attributes.md5 }}
+        - SHA-1: {{ steps.lookup_file_hash.output.attributes.sha1 }}
+        - SHA-256: {{ steps.lookup_file_hash.output.attributes.sha256 }}
+
+        Community Reputation:
+        - Reputation Score: {{ steps.lookup_file_hash.output.attributes.reputation }}
+        - Total Votes: {{ steps.lookup_file_hash.output.attributes.total_votes.harmless | plus: steps.lookup_file_hash.output.attributes.total_votes.malicious }}
+
+        Threat Assessment:
+        {% if steps.lookup_file_hash.output.stats.malicious > 5 %}
+        🚨 MALWARE DETECTED - Multiple AV engines flagged this file as malicious
+        {% elsif steps.lookup_file_hash.output.stats.malicious > 0 %}
+        ⚠️ POTENTIALLY MALICIOUS - Some AV engines detected threats
+        {% elsif steps.lookup_file_hash.output.stats.suspicious > 0 %}
+        ⚡ SUSPICIOUS - File shows suspicious characteristics
+        {% else %}
+        ✅ CLEAN - No malicious detections found
+        {% endif %}

--- a/library/workflows/hash-threat-check/hash-threat-check.yaml
+++ b/library/workflows/hash-threat-check/hash-threat-check.yaml
@@ -9,8 +9,7 @@ template-metadata:
     metadata, AV detection counts, community reputation, and an overall
     threat verdict.
   solutions: [security]
-  category: detection
-  tags: [detection, threat-intel, virustotal, hash, malware]
+  categories: [detection, enrichment, threat-intel]
   icon: virustotal
   install:
     form:

--- a/library/workflows/ip-reputation-check/ip-reputation-check.yaml
+++ b/library/workflows/ip-reputation-check/ip-reputation-check.yaml
@@ -1,0 +1,115 @@
+template-metadata:
+  slug: ip-reputation-check
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "IP Reputation Check (AbuseIPDB)"
+  description: >-
+    Assess the reputation of an IP address using AbuseIPDB and enrich the
+    result with geolocation data from IP-API. Produces a human-readable
+    threat report including abuse confidence score, total reports, geographic
+    origin, ISP, and a low / medium / high risk classification.
+  solutions: [security]
+  category: enrichment
+  tags: [enrichment, threat-intel, ip-reputation]
+  icon: abuseipdb
+  install:
+    form:
+      - name: abuseipdb-connector
+        label: "AbuseIPDB connector"
+        description: >-
+          The AbuseIPDB connector used to query IP reputation. If you don't
+          have one yet, click "Create new" and configure it with your
+          AbuseIPDB API key (https://www.abuseipdb.com/account/api).
+        inputType: connector
+        connectorType: .abuseipdb
+        required: true
+      - name: max-age-in-days
+        label: "Lookback window (days)"
+        description: >-
+          Maximum age of abuse reports to consider when scoring the IP, in
+          days. The default of 90 is a sensible starting point for most SOC
+          workflows; lower it for fresher signal, raise it for broader
+          historical context.
+        inputType: number
+        required: true
+        default: 90
+
+name: IP Reputation Check
+description: Check IP address reputation using AbuseIPDB and enrich with geolocation data.
+
+triggers:
+  - type: manual
+    inputs:
+      - name: ip_address
+        type: string
+        description: >-
+          The IP address to check for malicious activity and threat
+          intelligence (e.g., 8.8.8.8).
+        required: true
+
+steps:
+  # Query AbuseIPDB via the dedicated step type. The API key lives in the
+  # connector configuration, so no credential appears in this YAML.
+  - name: check_abuseipdb
+    type: abuseipdb.checkIp
+    connector-id: __install__.abuseipdb-connector
+    with:
+      ipAddress: "{{ inputs.ip_address }}"
+      maxAgeInDays: __install__.max-age-in-days
+    on-failure:
+      retry:
+        max-attempts: 2
+        delay: 3s
+      continue: true
+
+  # Geolocation enrichment via the public IP-API service. No auth required.
+  - name: get_geolocation
+    type: http
+    with:
+      url: http://ip-api.com/json
+      path: "{{ inputs.ip_address }}"
+      method: GET
+      query:
+        fields: "status,message,country,countryCode,region,regionName,city,zip,lat,lon,timezone,isp,org,as,asname,mobile,proxy,hosting"
+    on-failure:
+      retry:
+        max-attempts: 2
+        delay: 2s
+      continue: true
+
+  # Format and emit a human-readable report to the workflow execution logs.
+  - name: format_results
+    type: console
+    with:
+      message: |
+        === IP Threat Intelligence Report ===
+        IP Address: {{ inputs.ip_address }}
+
+        AbuseIPDB Results:
+        - Abuse Confidence Score: {{ steps.check_abuseipdb.output.data.abuseConfidenceScore }}%
+        - Total Reports: {{ steps.check_abuseipdb.output.data.totalReports }}
+        - Is Whitelisted: {{ steps.check_abuseipdb.output.data.isWhitelisted }}
+        - Country: {{ steps.check_abuseipdb.output.data.countryCode }}
+        - Usage Type: {{ steps.check_abuseipdb.output.data.usageType }}
+        - ISP: {{ steps.check_abuseipdb.output.data.isp }}
+        - Domain: {{ steps.check_abuseipdb.output.data.domain }}
+
+        Geolocation Results:
+        - Country: {{ steps.get_geolocation.output.data.country }} ({{ steps.get_geolocation.output.data.countryCode }})
+        - Region: {{ steps.get_geolocation.output.data.regionName }}
+        - City: {{ steps.get_geolocation.output.data.city }}
+        - ISP: {{ steps.get_geolocation.output.data.isp }}
+        - Organization: {{ steps.get_geolocation.output.data.org }}
+        - AS Name: {{ steps.get_geolocation.output.data.asname }}
+        - Is Proxy: {{ steps.get_geolocation.output.data.proxy }}
+        - Is Hosting: {{ steps.get_geolocation.output.data.hosting }}
+        - Is Mobile: {{ steps.get_geolocation.output.data.mobile }}
+
+        Threat Assessment:
+        {% if steps.check_abuseipdb.output.data.abuseConfidenceScore > 75 %}
+        ⚠️ HIGH RISK - This IP has a high abuse confidence score
+        {% elsif steps.check_abuseipdb.output.data.abuseConfidenceScore > 25 %}
+        ⚡ MEDIUM RISK - This IP has been reported for abuse
+        {% else %}
+        ✅ LOW RISK - No significant abuse reports
+        {% endif %}

--- a/library/workflows/ip-reputation-check/ip-reputation-check.yaml
+++ b/library/workflows/ip-reputation-check/ip-reputation-check.yaml
@@ -9,8 +9,7 @@ template-metadata:
     threat report including abuse confidence score, total reports, geographic
     origin, ISP, and a low / medium / high risk classification.
   solutions: [security]
-  category: enrichment
-  tags: [enrichment, threat-intel, ip-reputation]
+  categories: [enrichment, threat-intel]
   icon: abuseipdb
   install:
     form:

--- a/library/workflows/mark-alert-as-acknowledged/mark-alert-as-acknowledged.yaml
+++ b/library/workflows/mark-alert-as-acknowledged/mark-alert-as-acknowledged.yaml
@@ -1,0 +1,34 @@
+template-metadata:
+  slug: mark-alert-as-acknowledged
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "Mark Alert as Acknowledged"
+  description: >-
+    Set the status of a detection alert to "acknowledged" via the Security
+    Detection Engine API. Useful as a quick triage action or as a building
+    block for larger response workflows.
+  solutions: [security]
+  category: detection
+  tags: [detection, alerts, triage, acknowledge]
+
+name: Mark Alert as Acknowledged
+description: Set the status of a Security detection alert to "acknowledged".
+
+triggers:
+  - type: manual
+    inputs:
+      - name: alert_id
+        type: string
+        description: >-
+          The alert ID to acknowledge. Use the `_id` field from the alert
+          document or the `kibana.alert.uuid` value.
+        required: true
+
+steps:
+  # Acknowledge the alert via the Security step
+  - name: acknowledge_alert
+    type: security.setAlertStatus
+    with:
+      status: acknowledged
+      alert_ids: 
+        - "{{ inputs.alert_id }}"

--- a/library/workflows/mark-alert-as-acknowledged/mark-alert-as-acknowledged.yaml
+++ b/library/workflows/mark-alert-as-acknowledged/mark-alert-as-acknowledged.yaml
@@ -8,8 +8,7 @@ template-metadata:
     Detection Engine API. Useful as a quick triage action or as a building
     block for larger response workflows.
   solutions: [security]
-  category: detection
-  tags: [detection, alerts, triage, acknowledge]
+  categories: [response]
 
 name: Mark Alert as Acknowledged
 description: Set the status of a Security detection alert to "acknowledged".

--- a/library/workflows/root-cause-analysis/root-cause-analysis.yaml
+++ b/library/workflows/root-cause-analysis/root-cause-analysis.yaml
@@ -8,8 +8,7 @@ template-metadata:
     possible root causes, then file a Case with the agent's analysis,
     a generated title and description, the alert attached, and a
     structured summary of the agent's reasoning steps as comments.
-  category: automation
-  tags: [observability, rca, ai, agent-builder, cases]
+  categories: [root-cause-analysis, ai-agent, case-management]
   install:
     form:
       - name: agent-id

--- a/library/workflows/root-cause-analysis/root-cause-analysis.yaml
+++ b/library/workflows/root-cause-analysis/root-cause-analysis.yaml
@@ -1,0 +1,153 @@
+template-metadata:
+  slug: root-cause-analysis
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "Root Cause Analysis (Agent Builder)"
+  description: >-
+    On every triggering alert, ask an Agent Builder agent to investigate
+    possible root causes, then file a Case with the agent's analysis,
+    a generated title and description, the alert attached, and a
+    structured summary of the agent's reasoning steps as comments.
+  category: automation
+  tags: [observability, rca, ai, agent-builder, cases]
+  install:
+    form:
+      - name: agent-id
+        label: "Agent Builder agent ID"
+        description: >-
+          The Agent Builder agent that performs the root-cause analysis.
+          The default "sre-agent" matches the out-of-the-box SRE agent;
+          point it at a different agent if you have a custom one
+          configured for your environment.
+        inputType: text
+        required: true
+        default: "sre-agent"
+
+name: Root Cause Analysis
+description: Use an Agent Builder agent to investigate alerts and document findings as a Case.
+
+triggers:
+  - type: alert
+
+steps:
+  # Phase 1: ask the agent to investigate the triggering alert. `create-conversation: true`
+  # opens a conversation that subsequent steps continue via `conversation_id`.
+  - name: rca_analysis
+    type: ai.agent
+    agent-id: __install__.agent-id
+    create-conversation: true
+    with:
+      message: |
+        Investigate the following alerts: {{ event | json }} and provide possible root causes.
+        To not blow up your context window please keep your analysis and data exploration brief.
+
+        You may use emojis in your response.
+    timeout: 10m
+
+  # Phase 2: derive a Case title from the analysis (continues the same conversation).
+  - name: create_case_title
+    type: ai.agent
+    agent-id: __install__.agent-id
+    with:
+      conversation_id: "{{ steps.rca_analysis.output.conversation_id }}"
+      message: |
+        based on this analysis i am going to create a case. please come up with a case title for me that is clear and informative. only return the case title NOTHING ELSE.
+    timeout: 10m
+
+  # Phase 3: derive a Case description from the same conversation.
+  - name: create_case_description
+    type: ai.agent
+    agent-id: __install__.agent-id
+    with:
+      conversation_id: "{{ steps.rca_analysis.output.conversation_id }}"
+      message: |
+        based on this analysis i am going to create a case. please come up with a case description for me that is clear and informative. only return the case description NOTHING ELSE.
+    timeout: 10m
+
+  # Phase 4: open the Case with the generated title and description.
+  - name: create_case
+    type: cases.createCase
+    with:
+      title: "{{ steps.create_case_title.output.message }}"
+      description: "{{ steps.create_case_description.output.message }}"
+      owner: observability
+      severity: low
+      tags:
+        - rca
+      settings:
+        syncAlerts: false
+
+  # Phase 5: attach the triggering alert to the new Case.
+  - name: add_alert_to_case
+    type: cases.addAlerts
+    with:
+      case_id: "{{ steps.create_case.output.case.id }}"
+      alerts:
+        - alertId: "{{ event.alerts[0]._id }}"
+          index: "{{ event.alerts[0]._index }}"
+          rule:
+            id: "{{ event.rule.id }}"
+            name: "{{ event.rule.name }}"
+
+  # Phase 6: fetch the full agent conversation so its reasoning can be summarized.
+  - name: get_conversation
+    type: kibana.request
+    with:
+      method: GET
+      path: "/api/agent_builder/conversations/{{ steps.rca_analysis.output.conversation_id }}"
+
+  # Phase 7: append a structured summary of the agent's reasoning steps as a comment.
+  - name: add_reasoning_to_case
+    type: cases.addComment
+    with:
+      case_id: "{{ steps.create_case.output.case.id }}"
+      comment: |
+        ## 🔍 AI Investigation Summary
+        [View Full Conversation]({{ context.kibanaUrl }}/app/agent_builder/conversations/{{ steps.get_conversation.output.id }})
+
+        ### Investigation Steps
+
+        {%- assign step_number = 0 %}
+        {%- for round in steps.get_conversation.output.rounds %}
+        {%- for step in round.steps %}
+        {%- if step.type == "reasoning" %}
+        {%- assign step_number = step_number | plus: 1 %}
+
+        **{{ step_number }}. Reasoning**
+        > {{ step.reasoning }}
+
+        {%- elsif step.type == "tool_call" %}
+        {%- assign query_esql = "" %}
+        {%- assign result_count = 0 %}
+        {%- assign has_error = false %}
+        {%- assign error_message = "" %}
+        {%- for result in step.results %}
+        {%- if result.type == "error" %}
+        {%- assign has_error = true %}
+        {%- assign error_message = result.data.message %}
+        {%- elsif result.type == "query" %}
+        {%- assign query_esql = result.data.esql %}
+        {%- elsif result.type == "tabular_data" %}
+        {%- assign result_count = result.data.values | size %}
+        {%- endif %}
+        {%- endfor %}
+
+        **Action:** `{{ step.tool_id }}`
+        {%- if has_error %}
+        - ❌ **Error:** {{ error_message }}
+        {%- elsif query_esql != "" %}
+        - ✅ **Found {{ result_count }} results** → [View in Discover]({{ context.kibanaUrl }}/app/discover#/?_a=(dataSource:(type:esql),query:(esql:'{{ query_esql | url_encode }}')))
+        {%- else %}
+        - ✅ **Completed**
+        {%- endif %}
+
+        {%- endif %}
+        {%- endfor %}
+        {%- endfor %}
+
+  # Phase 8: append the original RCA analysis as a final comment on the Case.
+  - name: add_rca_as_comment
+    type: cases.addComment
+    with:
+      case_id: "{{ steps.create_case.output.case.id }}"
+      comment: "{{ steps.rca_analysis.output.message }}"

--- a/library/workflows/semantic-knowledge-search/semantic-knowledge-search.yaml
+++ b/library/workflows/semantic-knowledge-search/semantic-knowledge-search.yaml
@@ -7,8 +7,8 @@ template-metadata:
     Run a semantic search against a knowledge-base index using a natural
     language query, with optional namespace and knowledge-type filters
     applied as Elasticsearch term clauses.
-  category: search
-  tags: [search, semantic, knowledge-base, elasticsearch]
+  solutions: [search]
+  categories: [search]
   install:
     form:
       - name: knowledge-base-index

--- a/library/workflows/semantic-knowledge-search/semantic-knowledge-search.yaml
+++ b/library/workflows/semantic-knowledge-search/semantic-knowledge-search.yaml
@@ -1,0 +1,91 @@
+template-metadata:
+  slug: semantic-knowledge-search
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "Semantic Knowledge Search"
+  description: >-
+    Run a semantic search against a knowledge-base index using a natural
+    language query, with optional namespace and knowledge-type filters
+    applied as Elasticsearch term clauses.
+  category: search
+  tags: [search, semantic, knowledge-base, elasticsearch]
+  install:
+    form:
+      - name: knowledge-base-index
+        label: "Knowledge base index"
+        description: >-
+          The Elasticsearch index that holds your knowledge-base documents.
+          The default ("knowledge_base") matches the out-of-the-box layout;
+          change it to point at your own index.
+        inputType: esIndex
+        required: true
+        default: "knowledge_base"
+
+name: Semantic Knowledge Search
+description: Search for similar knowledge using semantic search with optional namespace and type filters.
+
+triggers:
+  - type: manual
+    inputs:
+      - name: query_text
+        type: string
+        description: Natural-language description of the knowledge you're looking for.
+        required: true
+      - name: namespace_root
+        type: string
+        description: |
+          Optional root namespace filter:
+          - "integration" for integration-specific knowledge
+          - "kibana" for Kibana patterns
+          - "elasticsearch" for Elasticsearch patterns
+        required: false
+      - name: namespace_scope
+        type: string
+        description: |
+          Optional scope filter:
+          - When root="integration": integration name (e.g., "1password", "kubernetes")
+          - When root="kibana": product area (e.g., "visualizations", "dashboards")
+          - When root="elasticsearch": product area (e.g., "pipelines")
+        required: false
+      - name: knowledge_type
+        type: string
+        description: Optional filter (e.g., 'security_use_case', 'field_group', 'detection_pattern').
+        required: false
+
+steps:
+  # Build the array of Elasticsearch term-filter clauses from the optional
+  # inputs. Liquid renders the JSON string, which `data.parseJson` then
+  # converts into a structured array consumable by the query DSL below.
+  - name: filters
+    type: data.parseJson
+    source: |
+      {% assign filters = "" | split: "" %}
+      {% if inputs.knowledge_type %}
+        {% assign filter_obj = '{"term": {"knowledge_type": "' | append: inputs.knowledge_type | append: '"}}' %}
+        {% assign filters = filters | push: filter_obj %}
+      {% endif %}
+      {% if inputs.namespace_root %}
+        {% assign filter_obj = '{"term": {"namespace.root": "' | append: inputs.namespace_root | append: '"}}' %}
+        {% assign filters = filters | push: filter_obj %}
+      {% endif %}
+      {% if inputs.namespace_scope %}
+        {% assign filter_obj = '{"term": {"namespace.scope": "' | append: inputs.namespace_scope | append: '"}}' %}
+        {% assign filters = filters | push: filter_obj %}
+      {% endif %}
+      [{{ filters | join: "," }}]
+
+  # Execute the semantic search, combining a `semantic` clause on the query
+  # text with the optional term filters built above.
+  - name: search_knowledge
+    type: elasticsearch.search
+    with:
+      index: __install__.knowledge-base-index
+      size: 5
+      query:
+        bool:
+          should:
+            - semantic:
+                field: semantic_summary
+                query: "{{ inputs.query_text }}"
+          must: ${{ steps.filters.output }}
+          minimum_should_match: 1

--- a/library/workflows/web-search/web-search.yaml
+++ b/library/workflows/web-search/web-search.yaml
@@ -1,0 +1,44 @@
+template-metadata:
+  slug: web-search
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "Web Search (Brave)"
+  description: >-
+    Run a web search via the Brave Search API and return the raw result
+    set. Useful as a building block for enrichment, research, or
+    LLM-grounding workflows.
+  category: search
+  tags: [search, web, brave]
+  icon: brave
+  install:
+    form:
+      - name: brave-search-connector
+        label: "Brave Search connector"
+        description: >-
+          The Brave Search connector used to perform the query. If you
+          don't have one yet, click "Create new" and configure it with
+          your Brave Search subscription token
+          (https://brave.com/search/api/).
+        inputType: connector
+        connectorType: .brave-search
+        required: true
+
+name: Web Search
+description: Perform a web search using the Brave Search API.
+
+triggers:
+  - type: manual
+    inputs:
+      - name: query
+        type: string
+        description: The query string to send to Brave Search.
+        required: true
+
+steps:
+  # Run the search via the dedicated Brave step type. The subscription
+  # token lives in the connector configuration.
+  - name: web_search
+    type: brave-search.webSearch
+    connector-id: __install__.brave-search-connector
+    with:
+      q: "{{ inputs.query }}"

--- a/library/workflows/web-search/web-search.yaml
+++ b/library/workflows/web-search/web-search.yaml
@@ -7,8 +7,7 @@ template-metadata:
     Run a web search via the Brave Search API and return the raw result
     set. Useful as a building block for enrichment, research, or
     LLM-grounding workflows.
-  category: search
-  tags: [search, web, brave]
+  categories: [search]
   icon: brave
   install:
     form:


### PR DESCRIPTION
## Summary 

Workflow Template Library — Phase 1, Task 1: starter set migration

Migrates the seven starter templates from `workflows/` into the new `library/workflows/<slug>/<slug>.yaml` layout introduced for the Workflow Template Library (Tech Preview, 9.5). Each template now carries a `template-metadata:` block with `slug`, `version`, `availability`, `name`, `description`, `solutions`, `category`, `tags`, optional `icon`, and (when needed) an `install.form` describing the install-time inputs the body references via `__install__.<name>`.

Per the Phase 1 proposal, the legacy `workflows/` tree is left untouched — this PR is additive.

### Templates migrated

- `ip-reputation-check` — switched from raw `http` to the dedicated `abuseipdb.checkIp` step; `.abuseipdb` connector + `max-age-in-days` (number, default 90) install fields.
- `hash-threat-check` — single `virustotal.scanFileHash` step; dropped the unused `/files/{hash}/behaviours` HTTP escape-hatch step that had no downstream readers.
- `mark-alert-as-acknowledged` — single `security.setAlertStatus` step, no install form (no operator-configurable inputs).
- `semantic-knowledge-search` — kept `elasticsearch.search`; collapsed the two `console`-as-Liquid-sandbox steps from the source into a single `data.parseJson` step; `knowledge-base-index` install field (text, default `knowledge_base`).
- `web-search` — single `brave-search.webSearch` step; `.brave-search` connector install field.
- `create-slack-channel` — `slack2.createConversation` with `.slack2` connector install field; added an optional `is_private` runtime input (defaults preserve source behaviour); `solutions: [security, observability]` exercises the cross-solution path.
- `root-cause-analysis` — most complex; alert trigger, eight steps. Swapped three `kibana.request POST /api/agent_builder/converse` calls for the dedicated `ai.agent` step type (the `get_conversation` retrieval stays on `kibana.request` since there's no `ai.*` step for conversation fetch); single `agent-id` install field (default `sre-agent`).

### Conventions established across the set

- File path: `library/workflows/<slug>/<slug>.yaml`, slug matches the parent directory name.
- Install form field names: kebab-case (internal identifiers, substituted away at render time and never user-visible). Workflow body `inputs` keep snake-case.
- `install.form[].connectorType` must equal `.` + the step type's prefix (e.g. `slack2.*` ↔ `.slack2`, `abuseipdb.*` ↔ `.abuseipdb`).
- Tutorial banner comments from the source (`# CONSTANTS / # INPUTS / # TRIGGERS / # STEPS`) dropped; per-step comments trimmed to one short paragraph.
- 2-space YAML indentation throughout.
- Prefer the dedicated vendor step type when the schema offers one; fall back to `http` or `kibana.request` only as a documented escape hatch.

### Validation

Each file parses with `js-yaml` and was checked against the rule that every `__install__.<name>` reference in the body has a matching entry in `template-metadata.install.form` (and no orphan form fields). All seven pass.

### Decisions surfaced during migration

For each template I flagged in chat the choices that weren't mechanical — e.g. dropping the unused VirusTotal `behaviours` step, fixing the broken `consts.basePath` reference in the RCA template, promoting `index_name`/`max_age_in_days` from `consts:` to install fields, the `.slack2` vs `.slack_api` connector ID question, and a few output-shape assumptions for dedicated step types that the JSON Schema can't verify (most notably `abuseipdb.checkIp.output.data.*` and `ai.agent.output.message` / `output.conversation_id`). All worth a second look during review.

### Out of scope

- Multi-version coexistence (`<slug>/<slug>-v2.yaml`) — starter set is all v1.
- The CDN endpoint, the publish CI / catalog generator, and the `CONTRIBUTING.md` update — separate Phase 1 tasks, not in this PR.