### PR TITLE
[Library] Catalog with step and trigger types

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,6 @@
+# Cursor already respects .gitignore (node_modules/, dist/, etc. are covered).
+# Add ONLY committed files that bloat AI context without adding value.
+
+# Binaries in docs/examples
+docs/**/*.{png,jpg,jpeg,gif,pdf,svg}
+examples/**/*.{png,jpg,jpeg,gif,pdf,svg}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[package.json]
+insert_final_newline = false
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+package-lock.json
+
+# Hand-authored content; format deliberately, not in bulk.
+examples/
+library/
+docs/
+*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Every template lives at:
 library/workflows/<slug>/<slug>.yaml
 ```
 
-- The `<slug>` directory name and the YAML file name **must match the `slug` value** inside the file's `template-metadata` block. The catalog generator enforces this.
+- The `<slug>` directory name and the YAML file name **must match the `slug` value** inside the file's `template-metadata` block. (Enforced by the validation step, planned to run in CI.)
 - Slug format: kebab-case, lowercase ASCII alphanumeric + hyphens. Should be descriptive and unique across the library.
 - One template per directory. Future multi-version coexistence will live as `<slug>/<slug>-v<n>.yaml` siblings, but the starter set is all v1.
 
@@ -60,7 +60,6 @@ template-metadata:
     with geolocation data. Produces a low / medium / high risk verdict.
   solutions: [security]                        # optional. absent or empty = cross-solution (every solution context)
   categories: [enrichment, threat-intel]       # closed-vocab; entries MUST exist in library/categories.yaml
-  icon: abuseipdb                              # optional; references a known icon ID
   install:                                     # only required when the body uses __install__.<name>
     form:
       - name: abuseipdb-connector
@@ -72,17 +71,16 @@ template-metadata:
 ```
 
 **Required fields:** `slug`, `version`, `availability`, `name`, `description`, `categories`.
-**Optional fields:** `solutions`, `icon`, `install`.
+**Optional fields:** `solutions`, `install`.
 
 Notes on the optional fields:
 
 - **`solutions`** — when present, an array of solution ids (e.g. `[security]`, `[security, observability]`). Absent or empty means the template is **cross-solution** and appears in every solution context.
-- **`icon`** — references an icon known to the Kibana UI (e.g. `abuseipdb`, `slack`, `virustotal`). Omit if there's no obvious match yet.
 - **`install`** — required if and only if the workflow body references any `__install__.<name>` placeholder. See [Install-time inputs](#install-time-inputs-installform--__install__) below.
 
 ### Categories vocabulary
 
-`categories: [...]` is a **closed vocabulary**. Every value used in any template's `categories` array must exist as an `id` in [`library/categories.yaml`](./library/categories.yaml). The catalog generator rejects any template referencing an unknown id.
+`categories: [...]` is a **closed vocabulary**. Every value used in any template's `categories` array must exist as an `id` in [`library/categories.yaml`](./library/categories.yaml). The validation step (planned to run in CI) rejects any template referencing an unknown id.
 
 If your template genuinely needs a category that is not in the vocab, **add the entry to `library/categories.yaml` in the same PR** — never invent values used only in a template. Reviewers will either accept the new entry or point you at an existing one.
 
@@ -135,6 +133,8 @@ Two rules:
 1. **Prefer the dedicated vendor step type.** If a vendor has a dedicated step (e.g. `abuseipdb.checkIp`, `virustotal.scanFileHash`, `slack2.createConversation`, `brave-search.webSearch`), use it. The legacy generic `http` step is an escape hatch and should only appear when no dedicated step exists.
 2. **Never invent a step type or a connector type.** If you think one is missing, file an issue rather than working around it locally.
 
+The catalog generator derives `stepTypes` and `triggerTypes` for each template — the full `type` of every step (including nested steps) and every trigger — into the catalog row. The Library UI renders the step/trigger icons on each template card from these, which is why templates no longer carry a manual `icon` field.
+
 ### Style and idiomatic patterns
 
 - **2-space YAML indentation.**
@@ -148,7 +148,7 @@ Two rules:
 
 ## Validating locally
 
-The repo ships a small Node script that walks every template, validates its `template-metadata` block, verifies every `categories[]` entry against the vocab, and produces the per-Kibana-version catalogs the CDN serves.
+The repo ships a small Node script that walks every template, checks its `template-metadata` block has the required fields, and produces the per-Kibana-version catalogs the CDN serves.
 
 ```bash
 npm install
@@ -175,15 +175,13 @@ KIBANA_MAIN_VERSION=9.6.0 KIBANA_NAMED_MINORS="" npm run build:catalog
 
 ### What "valid" means
 
-The script enforces:
+The generator enforces only:
 
-- File parses with `js-yaml`.
-- `template-metadata` is present with all required fields.
-- `slug` matches the parent directory name.
-- `version` is valid semver; `availability` is a valid semver range.
-- Every `categories[]` entry exists in `library/categories.yaml`.
+- The file parses as YAML.
+- `template-metadata` is present with all required fields (`slug`, `version`, `availability`, `name`, `description`, `categories`).
+- At least one template is discovered.
 
-It does **not** re-validate what the sibling CI validation job already checks.
+Deeper authoring invariants — slug ⇄ directory parity, valid `version` semver and `availability` range, `categories[]` membership in the vocab, `install.form` ⇄ `__install__` consistency, and step/connector type validity — are delegated to the separate validation step (planned to run in CI), not the generator.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Two rules:
 
 ## Validating locally
 
-The repo ships a small Node script that walks every template, validates its `template-metadata` block, cross-checks `__install__.<name>` against `install.form`, verifies every `categories[]` entry against the vocab, and produces the per-Kibana-version catalogs the CDN serves.
+The repo ships a small Node script that walks every template, validates its `template-metadata` block, verifies every `categories[]` entry against the vocab, and produces the per-Kibana-version catalogs the CDN serves.
 
 ```bash
 npm install
@@ -182,9 +182,8 @@ The script enforces:
 - `slug` matches the parent directory name.
 - `version` is valid semver; `availability` is a valid semver range.
 - Every `categories[]` entry exists in `library/categories.yaml`.
-- Every `__install__.<name>` reference in the body has a matching `install.form` entry (and no orphan form fields).
 
-It does **not** yet validate the workflow body against the engine's step-type schema — that runs in a sibling CI job once the validator package is published. Until then, the safest check is to install your template into a local Kibana and run it.
+It does **not** re-validate what the sibling CI validation job already checks.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ template-metadata:
   description: "Assess the reputation of an IP address using AbuseIPDB."
   solutions: [security]                     # optional; omit for cross-solution
   categories: [enrichment, threat-intel]    # closed vocab; entries from library/categories.yaml
-  icon: abuseipdb                           # optional
   install:                                  # only when the body uses __install__.<name>
     form:
       - name: abuseipdb-connector
@@ -120,8 +119,8 @@ In Kibana 9.5+ (Tech Preview), the Workflows app reads the published catalogue f
 Consumers see:
 
 - `/v1/kibana-versions.json` — the resolved list of available catalogues.
-- `/v1/<version>/catalogs/templates.json` — the catalogue rows for a given Kibana version.
-- `/v1/templates/<slug>/<version>.yaml` — immutable, version-keyed template bodies.
+- `/v1/<version>/catalogs/templates.json` — the catalogue rows for a given Kibana version. Each row carries the template metadata plus generator-derived `stepTypes` / `triggerTypes`, which the Library UI uses to render step and trigger icons.
+- `/v1/templates/<slug>/<version>.yaml` — version-keyed template bodies. The URL for a given `(slug, version)` is stable, but the bytes may be republished in place to ship a fix, so they are not treated as immutable.
 
 The catalogue is republished on every merge to `main`.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import js from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['node_modules/', 'dist/'],
+  },
+  js.configs.recommended,
+  eslintConfigPrettier,
+  {
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.node,
+    },
+    rules: {
+      // Aligned with Kibana's JS baseline where it applies to Node scripts.
+      'no-var': 'error',
+      'prefer-const': 'error',
+      eqeqeq: ['error', 'allow-null'],
+      'no-debugger': 'error',
+    },
+  },
+];

--- a/library/workflows/create-slack-channel/create-slack-channel.yaml
+++ b/library/workflows/create-slack-channel/create-slack-channel.yaml
@@ -8,7 +8,6 @@ template-metadata:
     Useful as a building block for incident-response workflows that spin
     up a dedicated war-room channel per case or alert.
   categories: [integration]
-  icon: slack
   install:
     form:
       - name: slack-connector

--- a/library/workflows/hash-threat-check/hash-threat-check.yaml
+++ b/library/workflows/hash-threat-check/hash-threat-check.yaml
@@ -10,7 +10,6 @@ template-metadata:
     threat verdict.
   solutions: [security]
   categories: [detection, enrichment, threat-intel]
-  icon: virustotal
   install:
     form:
       - name: virustotal-connector

--- a/library/workflows/ip-reputation-check/ip-reputation-check.yaml
+++ b/library/workflows/ip-reputation-check/ip-reputation-check.yaml
@@ -10,7 +10,6 @@ template-metadata:
     origin, ISP, and a low / medium / high risk classification.
   solutions: [security]
   categories: [enrichment, threat-intel]
-  icon: abuseipdb
   install:
     form:
       - name: abuseipdb-connector

--- a/library/workflows/web-search/web-search.yaml
+++ b/library/workflows/web-search/web-search.yaml
@@ -9,7 +9,6 @@ template-metadata:
     LLM-grounding workflows.
   solutions: []
   categories: [search]
-  icon: brave
   install:
     form:
       - name: brave-search-connector

--- a/scripts/build-catalog.mjs
+++ b/scripts/build-catalog.mjs
@@ -25,36 +25,30 @@
  * back to stale data.
  */
 
-import { readFile, writeFile, mkdir, readdir, rm } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { createHash } from "node:crypto";
-import path from "node:path";
-import yaml from "js-yaml";
-import semver from "semver";
+import { readFile, writeFile, mkdir, readdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import semver from 'semver';
 
 // --- Paths ---------------------------------------------------------------
 
 const REPO_ROOT = process.cwd();
-const POLICY_FILE = path.join(REPO_ROOT, "kibana-versions.json");
-const CATEGORIES_FILE = path.join(REPO_ROOT, "library/categories.yaml");
-const TEMPLATES_DIR = path.join(REPO_ROOT, "library/workflows");
-const OUT = path.join(REPO_ROOT, "dist/v1");
+const POLICY_FILE = path.join(REPO_ROOT, 'kibana-versions.json');
+const TEMPLATES_DIR = path.join(REPO_ROOT, 'library/workflows');
+const OUT = path.join(REPO_ROOT, 'dist/v1');
 
 // --- Helpers -------------------------------------------------------------
 
-const log = (...args) => console.log("[build-catalog]", ...args);
-const warn = (...args) => console.warn("[build-catalog]", ...args);
+const log = (...args) => console.log('[build-catalog]', ...args);
+const warn = (...args) => console.warn('[build-catalog]', ...args);
 
 function readJson(file) {
-  return readFile(file, "utf8").then(JSON.parse);
+  return readFile(file, 'utf8').then(JSON.parse);
 }
-
-function readYaml(file) {
-  return readFile(file, "utf8").then((raw) => yaml.load(raw));
-}
-
 function sha256(buf) {
-  return "sha256:" + createHash("sha256").update(buf).digest("hex");
+  return 'sha256:' + createHash('sha256').update(buf).digest('hex');
 }
 
 // --- Step 1: Load policy file --------------------------------------------
@@ -62,19 +56,18 @@ function sha256(buf) {
 async function loadPolicy() {
   const policy = await readJson(POLICY_FILE);
 
-  if (!policy.latest) throw new Error("kibana-versions.json: missing `latest`");
-  if (!policy.oldest) throw new Error("kibana-versions.json: missing `oldest`");
-  if (!policy.cataloguePer)
-    throw new Error("kibana-versions.json: missing `cataloguePer`");
+  if (!policy.latest) throw new Error('kibana-versions.json: missing `latest`');
+  if (!policy.oldest) throw new Error('kibana-versions.json: missing `oldest`');
+  if (!policy.cataloguePer) throw new Error('kibana-versions.json: missing `cataloguePer`');
 
   if (!semver.valid(policy.oldest)) {
     throw new Error(
-      `kibana-versions.json: \`oldest\` must be a valid semver, got '${policy.oldest}'`,
+      `kibana-versions.json: \`oldest\` must be a valid semver, got '${policy.oldest}'`
     );
   }
-  if (policy.cataloguePer !== "minor") {
+  if (policy.cataloguePer !== 'minor') {
     throw new Error(
-      `kibana-versions.json: \`cataloguePer\` only supports 'minor' for now, got '${policy.cataloguePer}'`,
+      `kibana-versions.json: \`cataloguePer\` only supports 'minor' for now, got '${policy.cataloguePer}'`
     );
   }
 
@@ -87,21 +80,18 @@ async function resolveMainKibanaSemver() {
   const override = process.env.KIBANA_MAIN_VERSION;
   if (override) {
     if (!semver.valid(override)) {
-      throw new Error(
-        `KIBANA_MAIN_VERSION env var is not valid semver: '${override}'`,
-      );
+      throw new Error(`KIBANA_MAIN_VERSION env var is not valid semver: '${override}'`);
     }
     log(`Using KIBANA_MAIN_VERSION override: ${override}`);
     return override;
   }
 
-  const url =
-    "https://raw.githubusercontent.com/elastic/kibana/main/package.json";
+  const url = 'https://raw.githubusercontent.com/elastic/kibana/main/package.json';
   log(`Resolving main semver from ${url}`);
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(
-      `Failed to fetch ${url}: HTTP ${res.status}. Cannot resolve main's Kibana version.`,
+      `Failed to fetch ${url}: HTTP ${res.status}. Cannot resolve main's Kibana version.`
     );
   }
   const pkg = await res.json();
@@ -112,7 +102,7 @@ async function resolveMainKibanaSemver() {
   const clean = semver.coerce(pkg.version)?.version;
   if (!clean || !semver.valid(clean)) {
     throw new Error(
-      `Kibana main package.json .version='${pkg.version}' did not normalize to a valid semver`,
+      `Kibana main package.json .version='${pkg.version}' did not normalize to a valid semver`
     );
   }
   return clean;
@@ -126,94 +116,79 @@ async function resolveMainKibanaSemver() {
  * the operator at the two escape hatches (GITHUB_TOKEN, KIBANA_NAMED_MINORS).
  */
 function formatGitHubApiError(res, url, hasToken) {
-  const remaining = res.headers.get("x-ratelimit-remaining");
-  const reset = res.headers.get("x-ratelimit-reset");
-  const limit = res.headers.get("x-ratelimit-limit");
+  const remaining = res.headers.get('x-ratelimit-remaining');
+  const reset = res.headers.get('x-ratelimit-reset');
+  const limit = res.headers.get('x-ratelimit-limit');
 
-  const lines = [
-    `Failed to list elastic/kibana branches: HTTP ${res.status} from ${url}`,
-  ];
+  const lines = [`Failed to list elastic/kibana branches: HTTP ${res.status} from ${url}`];
 
-  const isRateLimit =
-    (res.status === 403 || res.status === 429) && remaining === "0";
+  const isRateLimit = (res.status === 403 || res.status === 429) && remaining === '0';
 
   if (isRateLimit) {
-    const resetAt = reset
-      ? new Date(Number(reset) * 1000).toISOString()
-      : "unknown";
-    lines.push("");
+    const resetAt = reset ? new Date(Number(reset) * 1000).toISOString() : 'unknown';
+    lines.push('');
     lines.push(
-      `Cause: GitHub API rate limit exhausted (used ${limit}/${limit}, resets at ${resetAt}).`,
+      `Cause: GitHub API rate limit exhausted (used ${limit}/${limit}, resets at ${resetAt}).`
     );
     if (!hasToken) {
-      lines.push("");
+      lines.push('');
       lines.push(
-        "You are calling the GitHub API unauthenticated, which is rate-limited to 60 requests/hour per IP.",
+        'You are calling the GitHub API unauthenticated, which is rate-limited to 60 requests/hour per IP.'
       );
-      lines.push("");
-      lines.push("Fixes (pick one):");
+      lines.push('');
+      lines.push('Fixes (pick one):');
+      lines.push('  1. Authenticate the call (raises the limit to 5,000/hour):');
+      lines.push('       export GITHUB_TOKEN=$(gh auth token)   # if you use the gh CLI');
+      lines.push('       # or any classic/fine-grained PAT — no scopes needed for public repos');
+      lines.push('       npm run build:catalog');
+      lines.push('  2. Skip the branch fetch entirely (for quick local iteration):');
       lines.push(
-        "  1. Authenticate the call (raises the limit to 5,000/hour):",
-      );
-      lines.push(
-        "       export GITHUB_TOKEN=$(gh auth token)   # if you use the gh CLI",
-      );
-      lines.push(
-        "       # or any classic/fine-grained PAT — no scopes needed for public repos",
-      );
-      lines.push("       npm run build:catalog");
-      lines.push(
-        "  2. Skip the branch fetch entirely (for quick local iteration):",
+        '       KIBANA_NAMED_MINORS="" npm run build:catalog                # zero named minors'
       );
       lines.push(
-        '       KIBANA_NAMED_MINORS="" npm run build:catalog                # zero named minors',
+        '       KIBANA_NAMED_MINORS="9.5,9.6" npm run build:catalog         # specific minors'
       );
-      lines.push(
-        '       KIBANA_NAMED_MINORS="9.5,9.6" npm run build:catalog         # specific minors',
-      );
-      lines.push("  3. Wait until the rate limit window resets and retry.");
+      lines.push('  3. Wait until the rate limit window resets and retry.');
     } else {
-      lines.push("");
+      lines.push('');
       lines.push(
-        "Your GITHUB_TOKEN is set but the authenticated rate limit (5,000/hour) is also exhausted.",
+        'Your GITHUB_TOKEN is set but the authenticated rate limit (5,000/hour) is also exhausted.'
       );
       lines.push(
-        "Wait until the reset time above, or use KIBANA_NAMED_MINORS to skip the API entirely.",
+        'Wait until the reset time above, or use KIBANA_NAMED_MINORS to skip the API entirely.'
       );
     }
   } else if (res.status === 401 || res.status === 403) {
-    lines.push("");
+    lines.push('');
     if (hasToken) {
       lines.push(
-        "Cause: GITHUB_TOKEN is set but was rejected by GitHub (expired, revoked, or invalid).",
+        'Cause: GITHUB_TOKEN is set but was rejected by GitHub (expired, revoked, or invalid).'
       );
-      lines.push("");
-      lines.push("Fixes:");
-      lines.push("  1. Refresh your token:");
-      lines.push("       export GITHUB_TOKEN=$(gh auth token)");
+      lines.push('');
+      lines.push('Fixes:');
+      lines.push('  1. Refresh your token:');
+      lines.push('       export GITHUB_TOKEN=$(gh auth token)');
       lines.push(
-        "  2. Or unset it to fall back to unauthenticated access (60 req/h is plenty for one run):",
+        '  2. Or unset it to fall back to unauthenticated access (60 req/h is plenty for one run):'
       );
-      lines.push("       unset GITHUB_TOKEN && npm run build:catalog");
-      lines.push("  3. Or skip the branch fetch entirely:");
+      lines.push('       unset GITHUB_TOKEN && npm run build:catalog');
+      lines.push('  3. Or skip the branch fetch entirely:');
       lines.push('       KIBANA_NAMED_MINORS="" npm run build:catalog');
     } else {
       lines.push(
-        "Cause: GitHub returned 403 without a rate-limit signature. Possibly an IP-level block or a transient issue.",
+        'Cause: GitHub returned 403 without a rate-limit signature. Possibly an IP-level block or a transient issue.'
       );
-      lines.push("");
-      lines.push("Try again, or skip the API:");
+      lines.push('');
+      lines.push('Try again, or skip the API:');
       lines.push('  KIBANA_NAMED_MINORS="" npm run build:catalog');
     }
   } else {
-    lines.push("");
-    lines.push(
-      "Unexpected HTTP status from the GitHub API. Re-run; if it persists, skip the API:",
-    );
+    lines.push('');
+    lines.push('Unexpected HTTP status from the GitHub API. Re-run; if it persists, skip the API:');
     lines.push('  KIBANA_NAMED_MINORS="" npm run build:catalog');
   }
 
-  return lines.join("\n");
+  return lines.join('\n');
 }
 
 async function discoverNamedMinors(oldest) {
@@ -223,35 +198,30 @@ async function discoverNamedMinors(oldest) {
   const override = process.env.KIBANA_NAMED_MINORS;
   if (override !== undefined) {
     const items = override
-      .split(",")
+      .split(',')
       .map((s) => s.trim())
       .filter(Boolean)
       .map((id) => {
         if (!/^\d+\.\d+$/.test(id)) {
           throw new Error(
-            `KIBANA_NAMED_MINORS contains non-minor id '${id}' (expected '<major>.<minor>')`,
+            `KIBANA_NAMED_MINORS contains non-minor id '${id}' (expected '<major>.<minor>')`
           );
         }
         return { id, kibana: `${id}.0`, active: true };
       });
-    log(
-      `Using KIBANA_NAMED_MINORS override: [${items.map((i) => i.id).join(", ") || "(empty)"}]`,
-    );
+    log(`Using KIBANA_NAMED_MINORS override: [${items.map((i) => i.id).join(', ') || '(empty)'}]`);
     return items;
   }
 
-  const url =
-    "https://api.github.com/repos/elastic/kibana/branches?per_page=100";
+  const url = 'https://api.github.com/repos/elastic/kibana/branches?per_page=100';
   const hasToken = Boolean(process.env.GITHUB_TOKEN);
-  log(
-    `Discovering named minors from ${url} (${hasToken ? "authenticated" : "unauthenticated"})`,
-  );
+  log(`Discovering named minors from ${url} (${hasToken ? 'authenticated' : 'unauthenticated'})`);
 
   // GitHub branches API paginates. Walk pages until empty.
   let page = 1;
   const branchNames = [];
   while (true) {
-    const headers = { Accept: "application/vnd.github+json" };
+    const headers = { Accept: 'application/vnd.github+json' };
     if (hasToken) {
       headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
     }
@@ -278,34 +248,20 @@ async function discoverNamedMinors(oldest) {
       return { id: name, kibana: repSemver, major, minor };
     })
     .filter(Boolean)
-    .filter((b) =>
-      semver.gte(b.kibana, `${oldestParsed.major}.${oldestParsed.minor}.0`),
-    )
+    .filter((b) => semver.gte(b.kibana, `${oldestParsed.major}.${oldestParsed.minor}.0`))
     // Highest first, deterministic order.
     .sort((a, b) => semver.rcompare(a.kibana, b.kibana))
     .map(({ id, kibana }) => ({ id, kibana, active: true }));
 
   log(
-    `Discovered ${minors.length} named minor(s): ${minors.map((m) => m.id).join(", ") || "(none)"}`,
+    `Discovered ${minors.length} named minor(s): ${minors.map((m) => m.id).join(', ') || '(none)'}`
   );
   return minors;
 }
 
-// --- Step 4: Load categories vocabulary ----------------------------------
+// --- Step 4: Discover and validate every template ------------------------
 
-async function loadCategoriesVocab() {
-  const vocab = await readYaml(CATEGORIES_FILE);
-  if (!vocab?.categories?.length) {
-    throw new Error(
-      "library/categories.yaml: missing or empty `categories` array",
-    );
-  }
-  return new Set(vocab.categories.map((c) => c.id));
-}
-
-// --- Step 5: Discover and validate every template ------------------------
-
-async function loadTemplates(validCategoryIds) {
+async function loadTemplates() {
   const slugs = await readdir(TEMPLATES_DIR);
   const templates = [];
 
@@ -315,25 +271,23 @@ async function loadTemplates(validCategoryIds) {
       warn(`${file}: not found`);
       continue;
     }
-    const raw = await readFile(file, "utf8");
+    const raw = await readFile(file, 'utf8');
     const parsed = yaml.load(raw);
-    const meta = parsed?.["template-metadata"];
+    const meta = parsed?.['template-metadata'];
 
     if (!meta) {
       throw new Error(`${file}: missing \`template-metadata\` block`);
     }
     for (const required of [
-      "slug",
-      "version",
-      "availability",
-      "name",
-      "description",
-      "categories",
+      'slug',
+      'version',
+      'availability',
+      'name',
+      'description',
+      'categories',
     ]) {
       if (meta[required] === undefined) {
-        throw new Error(
-          `${file}: missing required field \`template-metadata.${required}\``,
-        );
+        throw new Error(`${file}: missing required field \`template-metadata.${required}\``);
       }
     }
 
@@ -344,7 +298,8 @@ async function loadTemplates(validCategoryIds) {
       metadata: meta,
       body: raw,
       contentHash: sha256(raw),
-      fixedConnectors: deriveFixedConnectors(parsed),
+      stepTypes: deriveStepTypes(parsed),
+      triggerTypes: deriveTriggerTypes(parsed),
     });
   }
 
@@ -355,37 +310,65 @@ async function loadTemplates(validCategoryIds) {
   return templates;
 }
 
-// `fixedConnectors` lists the connector-type IDs the template hard-codes via
-// step `type:` (the part before the first `.`). Templates that route all
-// connector binding through `__install__.<name>` have an empty array.
-function deriveFixedConnectors(parsed) {
-  const steps = parsed?.steps ?? [];
-  const types = new Set();
-  for (const step of steps) {
-    if (typeof step?.type !== "string") continue;
-    const dot = step.type.indexOf(".");
-    if (dot <= 0) continue;
-    const prefix = step.type.slice(0, dot);
-    // Skip in-house Kibana / engine namespaces — only surface external connectors.
-    if (
-      [
-        "console",
-        "http",
-        "data",
-        "workflow",
-        "kibana",
-        "cases",
-        "elasticsearch",
-        "security",
-        "ai",
-        "inference",
-        "foreach",
-      ].includes(prefix)
-    )
-      continue;
-    types.add(prefix);
+// Returns the child-step arrays nested inside a step, mirroring the workflow
+// grammar's nesting constructs (foreach/while `steps`, if `steps`+`else`,
+// switch `cases[].steps`+`default`, parallel `branches[].steps`, merge `steps`).
+// Kept in sync with @kbn/workflows `getChildStepArrays` / `collectAllSteps` in
+// Kibana — if a new nesting construct is added there, mirror it here.
+function getChildStepArrays(step) {
+  const arrays = [];
+  if (Array.isArray(step?.steps)) arrays.push(step.steps);
+  if (Array.isArray(step?.else)) arrays.push(step.else);
+  if (Array.isArray(step?.default)) arrays.push(step.default);
+  if (Array.isArray(step?.cases)) {
+    for (const c of step.cases) if (Array.isArray(c?.steps)) arrays.push(c.steps);
   }
-  return [...types].sort();
+  if (Array.isArray(step?.branches)) {
+    for (const b of step.branches) if (Array.isArray(b?.steps)) arrays.push(b.steps);
+  }
+  return arrays;
+}
+
+// Flattens every step in the template, recursing into nested steps.
+function collectAllSteps(steps) {
+  const result = [];
+  for (const step of steps ?? []) {
+    if (!step || typeof step !== 'object') continue;
+    result.push(step);
+    for (const childSteps of getChildStepArrays(step)) {
+      result.push(...collectAllSteps(childSteps));
+    }
+  }
+  return result;
+}
+
+// Unique, document-order list of every `step.type` in the template (including
+// nested steps). Full type strings — the Library UI maps them to icons.
+function deriveStepTypes(parsed) {
+  const seen = new Set();
+  const result = [];
+  for (const step of collectAllSteps(parsed?.steps)) {
+    const type = step.type;
+    if (typeof type === 'string' && type && !seen.has(type)) {
+      seen.add(type);
+      result.push(type);
+    }
+  }
+  return result;
+}
+
+// Unique, document-order list of every `trigger.type` in the template.
+function deriveTriggerTypes(parsed) {
+  const seen = new Set();
+  const result = [];
+  for (const trigger of parsed?.triggers ?? []) {
+    const type = trigger?.type;
+    if (typeof type === 'string' && type && !seen.has(type)) {
+      seen.add(type);
+      result.push(type);
+    }
+  }
+  return result;
 }
 
 // --- Step 6: Build the catalog -------------------------------------------
@@ -409,10 +392,10 @@ function templateRow(t) {
     description: t.metadata.description,
     solutions: t.metadata.solutions,
     categories: t.metadata.categories,
-    icon: t.metadata.icon,
     definitionUrl: `templates/${t.slug}/${t.version}.yaml`,
     contentHash: t.contentHash,
-    fixedConnectors: t.fixedConnectors,
+    stepTypes: t.stepTypes,
+    triggerTypes: t.triggerTypes,
   };
 }
 
@@ -422,14 +405,10 @@ async function main() {
   const policy = await loadPolicy();
   const mainSemver = await resolveMainKibanaSemver();
   const namedMinors = await discoverNamedMinors(policy.oldest);
-  const validCategoryIds = await loadCategoriesVocab();
-  const allTemplates = await loadTemplates(validCategoryIds);
+  const allTemplates = await loadTemplates();
 
   // Compose the resolved Kibana-versions list: every named minor + `main` sentinel.
-  const resolvedVersions = [
-    ...namedMinors,
-    { id: "main", kibana: mainSemver, active: true },
-  ];
+  const resolvedVersions = [...namedMinors, { id: 'main', kibana: mainSemver, active: true }];
   log(`Resolved main → Kibana ${mainSemver}`);
 
   // Wipe + recreate dist/v1.
@@ -438,12 +417,8 @@ async function main() {
 
   // Emit the resolved kibana-versions.json (consumer-facing shape).
   await writeFile(
-    path.join(OUT, "kibana-versions.json"),
-    JSON.stringify(
-      { versions: resolvedVersions, latest: policy.latest },
-      null,
-      2,
-    ) + "\n",
+    path.join(OUT, 'kibana-versions.json'),
+    JSON.stringify({ versions: resolvedVersions, latest: policy.latest }, null, 2) + '\n'
   );
 
   // Emit per-version templates.json + manifest.json.
@@ -452,54 +427,54 @@ async function main() {
     if (v.active === false) continue;
 
     const rows = pickTemplatesFor(v.kibana, allTemplates).map(templateRow);
-    const catalogsDir = path.join(OUT, v.id, "catalogs");
+    const catalogsDir = path.join(OUT, v.id, 'catalogs');
     await mkdir(catalogsDir, { recursive: true });
 
     const templatesJsonBody =
       JSON.stringify(
         {
-          version: "v1",
+          version: 'v1',
           kibanaVersion: v.kibana,
           generatedAt,
           templates: rows,
         },
         null,
-        2,
-      ) + "\n";
-    await writeFile(
-      path.join(catalogsDir, "templates.json"),
-      templatesJsonBody,
-    );
+        2
+      ) + '\n';
+    await writeFile(path.join(catalogsDir, 'templates.json'), templatesJsonBody);
 
     const manifest = {
-      version: "v1",
-      kibanaVersionId: v.id,
-      effectiveKibanaSemver: v.kibana,
+      version: 'v1',
+      // Resolved Kibana semver for this catalog (e.g. "9.5.0"; for the `main`
+      // channel this is whatever main currently builds, e.g. "9.7.0"). Matches
+      // templates.json's `kibanaVersion`. The channel id lives in the URL path
+      // (/v1/<id>/) and in kibana-versions.json, so it is not duplicated here.
+      kibanaVersion: v.kibana,
       generatedAt,
-      hashes: { "catalogs/templates.json": sha256(templatesJsonBody) },
+      hashes: { 'catalogs/templates.json': sha256(templatesJsonBody) },
     };
     await writeFile(
-      path.join(OUT, v.id, "manifest.json"),
-      JSON.stringify(manifest, null, 2) + "\n",
+      path.join(OUT, v.id, 'manifest.json'),
+      JSON.stringify(manifest, null, 2) + '\n'
     );
 
     log(
-      `  → v1/${v.id}/  (kibana ${v.kibana}, ${rows.length} template${rows.length === 1 ? "" : "s"})`,
+      `  → v1/${v.id}/  (kibana ${v.kibana}, ${rows.length} template${rows.length === 1 ? '' : 's'})`
     );
   }
 
   // Emit each template body once at its version-keyed URL.
   for (const t of allTemplates) {
-    const dir = path.join(OUT, "templates", t.slug);
+    const dir = path.join(OUT, 'templates', t.slug);
     await mkdir(dir, { recursive: true });
     await writeFile(path.join(dir, `${t.version}.yaml`), t.body);
   }
   log(`  → v1/templates/  (${allTemplates.length} version-keyed YAML bodies)`);
 
-  log("Done.");
+  log('Done.');
 }
 
 main().catch((err) => {
-  console.error("[build-catalog] FAILED:", err.message);
+  console.error('[build-catalog] FAILED:', err.message);
   process.exit(1);
 });

--- a/scripts/build-catalog.mjs
+++ b/scripts/build-catalog.mjs
@@ -5,13 +5,12 @@
  * Reads:
  *   - kibana-versions.json    (policy: latest channel, oldest supported minor,
  *                              catalogue granularity)
- *   - library/categories.yaml (closed-vocab category registry)
  *   - library/workflows/<slug>/<slug>.yaml  (templates)
  *
  * Writes (under dist/v1/):
  *   - kibana-versions.json                          (resolved, consumer-facing)
  *   - <version-id>/catalogs/templates.json          (one per active Kibana version)
- *   - <version-id>/manifest.json                    (with effectiveKibanaSemver)
+ *   - <version-id>/manifest.json                    (with kibanaVersion)
  *   - templates/<slug>/<version>.yaml               (raw template body, version-keyed)
  *
  * Resolves the list of Kibana versions to catalogue dynamically:
@@ -20,9 +19,11 @@
  *   - Named minors are discovered from elastic/kibana's branch list via the
  *     GitHub API, filtered by `oldest` (semver floor) and `cataloguePer`.
  *
- * Fails closed: a malformed template, an unknown category, an unreachable
- * Kibana main, or a missing required field aborts the publish — never falls
- * back to stale data.
+ * This generator does not enforce authoring invariants (slug parity, semver
+ * ranges, categories-vocab membership, install-form references); those are
+ * delegated to the separate validation step (planned to run in CI). It still
+ * fails closed on a malformed template, a missing required field, or an
+ * unreachable Kibana main — never falling back to stale data.
  */
 
 import { readFile, writeFile, mkdir, readdir, rm } from 'node:fs/promises';
@@ -51,7 +52,7 @@ function sha256(buf) {
   return 'sha256:' + createHash('sha256').update(buf).digest('hex');
 }
 
-// --- Step 1: Load policy file --------------------------------------------
+// --- Load policy file --------------------------------------------
 
 async function loadPolicy() {
   const policy = await readJson(POLICY_FILE);
@@ -74,7 +75,7 @@ async function loadPolicy() {
   return policy;
 }
 
-// --- Step 2: Resolve `main`'s semver -------------------------------------
+// --- Resolve `main`'s semver -------------------------------------
 
 async function resolveMainKibanaSemver() {
   const override = process.env.KIBANA_MAIN_VERSION;
@@ -108,7 +109,7 @@ async function resolveMainKibanaSemver() {
   return clean;
 }
 
-// --- Step 3: Discover supported named minors from Kibana branches --------
+// --- Discover supported named minors from Kibana branches --------
 
 /**
  * Builds a multi-line, actionable error message for a non-2xx response from
@@ -259,7 +260,7 @@ async function discoverNamedMinors(oldest) {
   return minors;
 }
 
-// --- Step 4: Discover and validate every template ------------------------
+// --- Discover every template ------------------------
 
 async function loadTemplates() {
   const slugs = await readdir(TEMPLATES_DIR);
@@ -371,7 +372,7 @@ function deriveTriggerTypes(parsed) {
   return result;
 }
 
-// --- Step 6: Build the catalog -------------------------------------------
+// --- Build the catalog -------------------------------------------
 
 function pickTemplatesFor(kibanaSemver, allTemplates) {
   const bySlug = new Map();


### PR DESCRIPTION
Sets up repo linting/formatting and reworks the generated catalog for the Kibana Library UI.

- **`stepTypes` / `triggerTypes` per template:** `build-catalog.mjs` now derives the full `type` of every step (recursively, including nested steps) and every trigger, replacing `fixedConnectors` — so the Library UI can render step/trigger icons per template card, screenshot below.
- **Removed `icon`** from `template-metadata`; icons are now derived from the step/trigger types instead of being hand-set.
- **Simplified `manifest.json`** to a single `kibanaVersion` (the resolved semver), dropping the redundant `kibanaVersionId` / `effectiveKibanaSemver` — the channel id already lives in the URL path and `kibana-versions.json`.
- **Removed the category-vocab validation** from the generator — authoring invariants belong in the CI validation step, not the catalog build.
- Updated `CONTRIBUTING.md` to match.
- **Lint/format setup:** flat `eslint.config.js`, Prettier (`.prettierrc` + `.prettierignore`), `.editorconfig`, and `.cursorignore`.

### Why do we need `stepTypes` / `triggerTypes` in the catalog.

The cards in the library UI will show icons of the triggers and steps used in the workflow definition. We don't want to retrieve all the individual templates and parse them at runtime to generate those icons. Solution: include the list of `stepTypes` / `triggerTypes` in the catalog. They are not post-processed, values will be the raw `step.type` and `trigger.type`.

Reference mock from design:

<img width="1728" height="1119" alt="Workflows" src="https://github.com/user-attachments/assets/ba6795ef-1a3f-4948-b41b-387e2da37167" />

