### PR TITLE
[Library] add Buildkite catalog publish pipeline

### DIFF
--- a/.buildkite/pipelines/publish_catalog.yml
+++ b/.buildkite/pipelines/publish_catalog.yml
@@ -1,0 +1,14 @@
+# Buildkite steps for the Workflow Template Library catalog publisher.
+#
+# Registered via catalog-info.yaml (Backstage). Runs on merge to `main` and
+# publishes the generated catalog to the production CDN bucket.
+steps:
+  - label: ":cloud: Publish catalog → workflows.elastic.co"
+    command: .buildkite/scripts/publish_catalog.sh prod
+    timeout_in_minutes: 20
+    agents:
+      # TODO(eng-prod): confirm a core image/family that provides
+      # node 20 + gcloud/gsutil + vault out of the box (the script installs
+      # node as a fallback if the image doesn't ship it).
+      provider: gcp
+      image: family/core-ubuntu-2204

--- a/.buildkite/pipelines/publish_catalog.yml
+++ b/.buildkite/pipelines/publish_catalog.yml
@@ -7,8 +7,7 @@ steps:
     command: .buildkite/scripts/publish_catalog.sh prod
     timeout_in_minutes: 20
     agents:
-      # TODO(eng-prod): confirm a core image/family that provides
-      # node 20 + gcloud/gsutil + vault out of the box (the script installs
-      # node as a fallback if the image doesn't ship it).
-      provider: gcp
-      image: family/core-ubuntu-2204
+      # Kibana-owned CI image with node + Cloud SDK (gcloud) + vault preinstalled
+      # (recommended by eng-prod). Kibana owns version bumps; we can move to a
+      # newer nodejs image later since we only require node >= 20.
+      image: "docker.elastic.co/ci-agent-images/kibana/chainguard-nodejs-20"

--- a/.buildkite/scripts/publish_catalog.sh
+++ b/.buildkite/scripts/publish_catalog.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Publishes the Workflow Template Library catalog to its CDN-backed GCS bucket.
+#
+# Usage: publish_catalog.sh <prod|staging>
+#
+# Runs on a Buildkite agent, which already has repo-scoped Vault access
+# (secret/ci/elastic-workflows/*) via the standard agent env hook — no explicit
+# `vault login` is needed. The only privileged action is uploading generated,
+# public catalog files to a public, read-only bucket.
+#
+# See tracking issue elastic/security-team#18016.
+
+set -euo pipefail
+
+TARGET="${1:-prod}"
+
+case "$TARGET" in
+  prod)
+    BUCKET="elastic-workflows-library-prod"
+    DEST="v1"
+    ;;
+  staging)
+    # Staging is for maintainer-pushed branches only (fork PRs are not built on
+    # public repos). Published at the same path; a maintainer branch overwrites
+    # the previous staging preview.
+    BUCKET="elastic-workflows-library-staging"
+    DEST="v1"
+    ;;
+  *)
+    echo "Unknown target '${TARGET}' (expected 'prod' or 'staging')" >&2
+    exit 1
+    ;;
+esac
+
+# Vault is a network service; the CI docs recommend retrying its CLI calls.
+retry() {
+  local attempts=$1; shift
+  local delay=$1; shift
+  local n=1
+  until "$@"; do
+    local rc=$?
+    if (( n >= attempts )); then return "$rc"; fi
+    echo "Retry ${n}/$((attempts - 1)) after failure (rc=${rc}); sleeping ${delay}s" >&2
+    sleep "$delay"
+    n=$((n + 1))
+  done
+}
+
+echo "--- Build catalog"
+npm ci
+npm run build:catalog
+
+echo "--- Fetch GCS publisher credentials from Vault"
+# TODO(eng-prod): confirm the exact repo-scoped path + field where the
+# bekitzur-workflows service-account key lands (see elastic/security-team#18016).
+VAULT_SECRET_PATH="secret/ci/elastic-workflows/gcs-publish"
+VAULT_FIELD="credentials"
+GCS_SA_KEY="$(retry 5 5 vault read -field="${VAULT_FIELD}" "${VAULT_SECRET_PATH}")"
+
+echo "--- Authenticate to GCP"
+set +x  # never echo the service-account key
+gcloud auth activate-service-account --key-file <(echo "${GCS_SA_KEY}")
+
+echo "--- Publish dist/v1 → gs://${BUCKET}/${DEST}"
+# `rsync -d` mirrors the tree (deletes objects for templates removed from the
+# repo). Uniform short TTL + ETag revalidation per the catalog cache contract:
+# body URLs are stable but NOT immutable, so no `immutable` header.
+gsutil -m -h "Cache-Control:public, max-age=300" rsync -d -r dist/v1 "gs://${BUCKET}/${DEST}"
+
+echo "--- Done"

--- a/.buildkite/scripts/publish_catalog.sh
+++ b/.buildkite/scripts/publish_catalog.sh
@@ -15,17 +15,21 @@ set -euo pipefail
 
 TARGET="${1:-prod}"
 
+# The catalog is served under a `/library/` path prefix (e.g.
+# https://workflows.elastic.co/library/v1/...) so the same host/bucket can host
+# other content (public schemas, managed workflows, ...) under sibling prefixes.
+# `library/v1` is a real object-key prefix in the bucket, not a CDN rewrite.
 case "$TARGET" in
   prod)
     BUCKET="elastic-workflows-library-prod"
-    DEST="v1"
+    DEST="library/v1"
     ;;
   staging)
     # Staging is for maintainer-pushed branches only (fork PRs are not built on
     # public repos). Published at the same path; a maintainer branch overwrites
     # the previous staging preview.
     BUCKET="elastic-workflows-library-staging"
-    DEST="v1"
+    DEST="library/v1"
     ;;
   *)
     echo "Unknown target '${TARGET}' (expected 'prod' or 'staging')" >&2

--- a/.buildkite/scripts/publish_catalog.sh
+++ b/.buildkite/scripts/publish_catalog.sh
@@ -56,11 +56,11 @@ npm ci
 npm run build:catalog
 
 echo "--- Fetch GCS publisher credentials from Vault"
-# TODO(eng-prod): confirm the exact repo-scoped path + field where the
-# bekitzur-workflows service-account key lands (see elastic/security-team#18016).
-VAULT_SECRET_PATH="secret/ci/elastic-workflows/gcs-publish"
+# Repo-scoped CI secret, provisioned as a KV2Path resource in Terrazzo
+# (see elastic/security-team#18016). KV v2 → read with `vault kv get`.
+VAULT_SECRET_PATH="kv/ci-shared/workflows-library/gcs-publish"
 VAULT_FIELD="credentials"
-GCS_SA_KEY="$(retry 5 5 vault read -field="${VAULT_FIELD}" "${VAULT_SECRET_PATH}")"
+GCS_SA_KEY="$(retry 5 5 vault kv get -field="${VAULT_FIELD}" "${VAULT_SECRET_PATH}")"
 
 echo "--- Authenticate to GCP"
 set +x  # never echo the service-account key

--- a/.buildkite/scripts/publish_catalog.sh
+++ b/.buildkite/scripts/publish_catalog.sh
@@ -67,9 +67,14 @@ set +x  # never echo the service-account key
 gcloud auth activate-service-account --key-file <(echo "${GCS_SA_KEY}")
 
 echo "--- Publish dist/v1 → gs://${BUCKET}/${DEST}"
-# `rsync -d` mirrors the tree (deletes objects for templates removed from the
-# repo). Uniform short TTL + ETag revalidation per the catalog cache contract:
-# body URLs are stable but NOT immutable, so no `immutable` header.
-gsutil -m -h "Cache-Control:public, max-age=300" rsync -d -r dist/v1 "gs://${BUCKET}/${DEST}"
+# Mirror the tree with `gcloud storage rsync` (the recommended CLI; gsutil's
+# rsync is deprecated and unreliable on some platforms).
+# `--delete-unmatched-destination-objects` removes objects for templates deleted
+# from the repo. Short TTL per the catalog cache contract: body URLs are stable
+# but NOT immutable, so no `immutable` cache directive.
+gcloud storage rsync dist/v1 "gs://${BUCKET}/${DEST}" \
+  --recursive \
+  --delete-unmatched-destination-objects \
+  --cache-control="public, max-age=300"
 
 echo "--- Done"

--- a/.buildkite/scripts/publish_catalog.sh
+++ b/.buildkite/scripts/publish_catalog.sh
@@ -5,9 +5,9 @@
 # Usage: publish_catalog.sh <prod|staging>
 #
 # Runs on a Buildkite agent, which already has repo-scoped Vault access
-# (secret/ci/elastic-workflows/*) via the standard agent env hook — no explicit
-# `vault login` is needed. The only privileged action is uploading generated,
-# public catalog files to a public, read-only bucket.
+# (kv/ci-shared/workflows-library/gcs-publish) via the standard agent env
+# hook — no explicit `vault login` is needed. The only privileged action is
+# uploading generated, public catalog files to a public, read-only bucket.
 #
 # See tracking issue elastic/security-team#18016.
 
@@ -23,6 +23,7 @@ case "$TARGET" in
   prod)
     BUCKET="elastic-workflows-library-prod"
     DEST="library/v1"
+    CDN_BASE="https://workflows.elastic.co/library/v1"
     ;;
   staging)
     # Staging is for maintainer-pushed branches only (fork PRs are not built on
@@ -30,6 +31,7 @@ case "$TARGET" in
     # the previous staging preview.
     BUCKET="elastic-workflows-library-staging"
     DEST="library/v1"
+    CDN_BASE="https://workflows-staging.elastic.co/library/v1"
     ;;
   *)
     echo "Unknown target '${TARGET}' (expected 'prod' or 'staging')" >&2
@@ -61,9 +63,15 @@ echo "--- Fetch GCS publisher credentials from Vault"
 VAULT_SECRET_PATH="kv/ci-shared/workflows-library/gcs-publish"
 VAULT_FIELD="credentials"
 GCS_SA_KEY="$(retry 5 5 vault kv get -field="${VAULT_FIELD}" "${VAULT_SECRET_PATH}")"
+if [[ -z "${GCS_SA_KEY}" ]]; then
+  echo "Vault returned empty GCS credentials (${VAULT_SECRET_PATH}, field ${VAULT_FIELD})" >&2
+  exit 1
+fi
 
 echo "--- Authenticate to GCP"
-set +x  # never echo the service-account key
+set +x  # defensive: make sure the service-account key is never traced
+# Revoke the activated credentials when the script exits, even on failure.
+trap 'gcloud auth revoke --all 2>/dev/null || true' EXIT
 gcloud auth activate-service-account --key-file <(echo "${GCS_SA_KEY}")
 
 echo "--- Publish dist/v1 → gs://${BUCKET}/${DEST}"
@@ -76,5 +84,9 @@ gcloud storage rsync dist/v1 "gs://${BUCKET}/${DEST}" \
   --recursive \
   --delete-unmatched-destination-objects \
   --cache-control="public, max-age=300"
+
+echo "--- Annotate build"
+buildkite-agent annotate --style "success" --context "catalog-publish" \
+  "Published to ${CDN_BASE}/ — verify: \`curl -s ${CDN_BASE}/main/catalogs/templates.json | jq '.templates[].slug'\`"
 
 echo "--- Done"

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full authoring guide — requir
 
 In Kibana 9.5+ (Tech Preview), the Workflows app reads the published catalogue from the CDN and renders a browser of installable templates. Installing a template prompts the operator for the values declared in `install.form`, substitutes them for the `__install__.<name>` placeholders in the body, and persists the resulting workflow as a saved object — at which point it runs like any other workflow.
 
-Consumers see:
+Consumers see (all served under a `/library/` path prefix, leaving room for other content on the same host):
 
-- `/v1/kibana-versions.json` — the resolved list of available catalogues.
-- `/v1/<version>/catalogs/templates.json` — the catalogue rows for a given Kibana version.
-- `/v1/templates/<slug>/<version>.yaml` — immutable, version-keyed template bodies.
+- `/library/v1/kibana-versions.json` — the resolved list of available catalogues.
+- `/library/v1/<version>/catalogs/templates.json` — the catalogue rows for a given Kibana version.
+- `/library/v1/templates/<slug>/<version>.yaml` — immutable, version-keyed template bodies.
 
 The catalogue is republished on every merge to `main`.
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+#
+# Backstage catalog definition for elastic/workflows.
+#
+# This declares the repo as a Backstage Component and defines the Buildkite
+# pipeline that publishes the Workflow Template Library catalog to the CDN.
+#
+# NOTE: the repo must also be *enrolled* into Backstage via a Location entity in
+# the elastic/catalog-info repo (open it with Backstage → Create → "Register in
+# catalog"). Until that PR is merged and Terrazzo runs, this file has no effect.
+# See tracking issue elastic/security-team#18016.
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: workflows-library
+  description: >-
+    Source repo for the Kibana Workflow Template Library: curated workflow
+    templates and the catalog publisher that ships them to the CDN.
+  links:
+    - title: Workflow Template Library epic
+      url: https://github.com/elastic/security-team/issues/15748
+spec:
+  type: tool
+  # TODO(eng-prod): confirm the correct Backstage group slug for our team.
+  owner: group:workflows-eng
+  lifecycle: experimental
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-workflows-publish-catalog
+  description: Publishes the Workflow Template Library catalog to the CDN on merge to main
+spec:
+  type: buildkite-pipeline
+  # TODO(eng-prod): confirm the correct Backstage group slug for our team.
+  owner: group:workflows-eng
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: workflows / publish-catalog
+      description: Publishes the Workflow Template Library catalog to the CDN on merge to main
+    spec:
+      repository: elastic/workflows
+      pipeline_file: .buildkite/pipelines/publish_catalog.yml
+      default_branch: main
+      # Only build the main branch for the credentialed publish. Fork PRs are
+      # not built on public repos (platform constraint); PR validation is a
+      # separate, secret-free GitHub Actions workflow.
+      branch_configuration: main
+      provider_settings:
+        build_branches: true
+        build_pull_requests: false
+        trigger_mode: code
+      teams:
+        everyone:
+          access_level: BUILD_AND_READ
+        # TODO(eng-prod): confirm the Buildkite team slug for our team.
+        workflows-eng:
+          access_level: MANAGE_BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -84,6 +84,6 @@ spec:
         trigger_mode: code
       teams:
         everyone:
-          access_level: BUILD_AND_READ
+          access_level: READ_ONLY
         workflows-eng:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## Summary

Adds the Buildkite CI that publishes the Workflow Template Library catalog to the CDN on every merge to `main` (Phase 1 — the source/publish side in `elastic/workflows`).

## What's included

- **`catalog-info.yaml`** — Backstage `Component` + two `buildkite-pipeline` Resources:
  - `workflows` — the default repo pipeline (Renovate + `catalog-info.yaml` validation), from the repo bootstrap (#30).
  - `workflows / publish-catalog` — this feature. Publishes on merge to `main` (`build_pull_requests: false` — fork PRs aren't built on public repos; PR validation is a separate, secret-free workflow, see follow-ups).
- **`.buildkite/pipelines/publish_catalog.yml`** — the publish step. Runs on `docker.elastic.co/ci-agent-images/kibana/chainguard-nodejs-20`, which bundles node 20 + `gcloud` (Cloud SDK) + `vault`.
- **`.buildkite/scripts/publish_catalog.sh`** — `npm ci` → `npm run build:catalog` → read the GCS service-account key from the CI Vault (`vault kv get -field=credentials kv/ci-shared/workflows-library/gcs-publish`, with retry) → `gcloud auth activate-service-account` → `gcloud storage rsync --recursive --delete-unmatched-destination-objects --cache-control="public, max-age=300"` of `dist/v1` to `elastic-workflows-library-prod` under the **`/library/v1`** object-key prefix (served at `https://workflows.elastic.co/library/v1/…`; body URLs stable but not immutable).

## Platform enablement (done)

- Repo registered in Backstage — elastic/catalog-info#4256 + repo bootstrap #30.
- Repo-scoped CI Vault path provisioned via a KV2Path resource — elastic/terrazzo#1483; the GCS SA key is stored at `kv/ci-shared/workflows-library/gcs-publish`.
- Agent image confirmed to ship node 20 + `gcloud` + `vault`.
- eng-prod enablement request: elastic/platform-engineering-productivity#2916.

## Not included (follow-ups)

- PR validation workflow — interim `git clone kibana + bootstrap + validation script`, owned Kibana-side (@dej611); later, a Kibana-published JSON Schema. Tracked in elastic/security-team#18016 / elastic/security-team#18014.
- Air-gap release tarball (GitHub Release) — designed, tracked in elastic/security-team#18016.

## Testing

- Local: `bash -n` on the script, YAML parse of `catalog-info.yaml` / pipeline, and `npm run build:catalog` generates the `dist/v1` tree.
- End-to-end runs after merge: Terrazzo provisions the `workflows / publish-catalog` pipeline from `catalog-info.yaml`, then the first build reads the Vault key and publishes. Verify with:
  ```
  curl -s https://workflows.elastic.co/library/v1/main/catalogs/templates.json | jq '.templates[].slug'
  ```

## Notes

- Catalog `build-catalog.mjs` discovers Kibana versions via `git ls-remote` (no GitHub token needed) — merged separately in #20.

## References

- Tracking: elastic/security-team#18016
- eng-prod enablement: elastic/platform-engineering-productivity#2916
- Vault KV2Path: elastic/terrazzo#1483
- Backstage registration: elastic/catalog-info#4256
- Repo bootstrap: #30
- `build-catalog` git ls-remote: #20
- CDN infra: elastic/infra#44196
