### PR TITLE
[New] Disable Noisy Elastic Defend Behavior Rules

### DIFF
--- a/examples/security/detection/README.md
+++ b/examples/security/detection/README.md
@@ -2,10 +2,11 @@
 
 Threat detection, alerting, and rule management workflows
 
-## Workflows (8)
+## Workflows (9)
 
 | Workflow | Description |
 |----------|-------------|
+| [Disable Faulty Endpoint Behavior Rules](./disable-faulty-endpoint-rules-from-esql.yaml) | Detects noisy Defend rules via ES\|QL (FP bursts) and auto-creates scoped Endpoint Security exceptions by rule version; new artifact versions are unaffected |
 | [␆ Mark Alert as Acknowledged](./mark-alert-as-acknowledged.yaml) | This workflow YAML defines a manual trigger for acknowledging security alerts |
 | [🏷️ Add Alert Tag - FP](./add-alert-tag-fp.yaml) | This workflow YAML defines a manual trigger for adding a tag to a security alert |
 | [🏷️ Add Alert Tag - TP](./add-alert-tag-tp.yaml) | This workflow YAML defines a manual trigger for adding tags to an alert in a sec |

--- a/examples/security/detection/README.md
+++ b/examples/security/detection/README.md
@@ -6,7 +6,7 @@ Threat detection, alerting, and rule management workflows
 
 | Workflow | Description |
 |----------|-------------|
-| [Disable Faulty Endpoint Behavior Rules](./disable-faulty-endpoint-rules-from-esql.yaml) | Detects noisy Defend rules via ES\|QL (FP bursts) and auto-creates scoped Endpoint Security exceptions by rule version; new artifact versions are unaffected |
+| [Disable Noisy Elastic Defend Behavior Rules](./disable-noisy-endpoint-rules-from-esql.yaml) | Detects noisy Elastic Defend behavior rules via ES\|QL (FP bursts) and auto-creates scoped Endpoint Security exceptions by rule version; new artifact versions are unaffected |
 | [␆ Mark Alert as Acknowledged](./mark-alert-as-acknowledged.yaml) | This workflow YAML defines a manual trigger for acknowledging security alerts |
 | [🏷️ Add Alert Tag - FP](./add-alert-tag-fp.yaml) | This workflow YAML defines a manual trigger for adding a tag to a security alert |
 | [🏷️ Add Alert Tag - TP](./add-alert-tag-tp.yaml) | This workflow YAML defines a manual trigger for adding tags to an alert in a sec |

--- a/examples/security/detection/disable-faulty-endpoint-rules-from-esql.yaml
+++ b/examples/security/detection/disable-faulty-endpoint-rules-from-esql.yaml
@@ -1,0 +1,139 @@
+# =============================================================================
+# Workflow: Disable Faulty Endpoint Rules from ES|QL
+# Category: security/detection
+#
+# Detects noisy Elastic Defend behavior rules (FP bursts across many hosts and
+# processes) via ES|QL and auto-creates scoped Endpoint Security
+# exceptions per rule name, policy artifact version, data_stream.namespace,
+# and host.os.type. Remediates the faulty rule version without blocking
+# future artifact updates — a new policy version runs normally and is not
+# covered by existing exceptions.
+#
+# 1. Runs an ES|QL query that finds rules firing on many hosts and many
+#    distinct processes (likely faulty / noisy rules). Query returns at least:
+#    [0] rule.name, [1] Endpoint.policy.applied.artifacts.global.version,
+#    [2] data_stream.namespace, [3] host.os.type
+# 2. For each row, creates one Endpoint Security Exception (if not already
+#    present): rule.name + policy version + namespace + os_types from
+#    host.os.type. Deterministic item_id (409 = skip).
+#
+# Schedule: every 31 minutes (manual trigger also available).
+#
+# References:
+# - Endpoint Security Exception List: Security -> Rules -> Shared exception
+#   lists -> Endpoint Security Exception List
+# - https://www.elastic.co/docs/solutions/security/detect-and-alert/add-manage-exceptions
+# =============================================================================
+version: "1"
+name: Disable Faulty Endpoint Behavior Rules
+description: |
+  Detect noisy Defend rules via ES|QL and create scoped Endpoint exceptions
+  (rule.name + policy version + namespace + OS). Skips if already present.
+  Remediates FP bursts by rule version; new artifact versions are unaffected.
+enabled: true
+tags:
+  - security
+  - endpoint
+  - exceptions
+  - detection
+
+# -----------------------------------------------------------------------------
+# INPUTS
+# -----------------------------------------------------------------------------
+inputs:
+  - name: esql_query
+    type: string
+    description: ES|QL query. Columns [0] rule.name, [1] Endpoint.policy.applied.artifacts.global.version, [2] data_stream.namespace, [3] host.os.type.
+    required: true
+    default: |
+      FROM logs-endpoint.alerts*
+      | WHERE @timestamp > NOW() - 30 minute and rule.name is not null and event.code == "behavior" and process.code_signature.trusted == true and process.parent.code_signature.trusted == true
+      | STATS alerts_count = COUNT(*), host_count = COUNT_DISTINCT(host.id), proc_count = COUNT_DISTINCT(process.name), parent_count = COUNT_DISTINCT(process.parent.name) BY rule.name, Endpoint.policy.applied.artifacts.global.version, data_stream.namespace, host.os.type
+      | WHERE (host_count >= 5 and proc_count >= 3) or host_count >= 20
+      | STATS BY rule.name, Endpoint.policy.applied.artifacts.global.version, data_stream.namespace, host.os.type
+
+# -----------------------------------------------------------------------------
+# TRIGGERS — manual + every 31 minutes
+# -----------------------------------------------------------------------------
+triggers:
+  - type: manual
+  - type: scheduled
+    with:
+      every: 31m
+
+# -----------------------------------------------------------------------------
+# STEPS
+# -----------------------------------------------------------------------------
+steps:
+  - name: run_esql
+    type: elasticsearch.esql.query
+    with:
+      query: "{{ inputs.esql_query }}"
+
+  - name: per_row_create_exception
+    type: foreach
+    foreach: "{{ steps.run_esql.output.values }}"
+    steps:
+      - name: get_exception
+        type: kibana.request
+        with:
+          method: GET
+          path: "/api/endpoint_list/items/_find"
+          query:
+            filter: "item_id:tune-{{ foreach.item[0] | replace: ' ', '-' }}-{{ foreach.item[1] | replace: ' ', '-' }}-{{ foreach.item[2] | replace: ' ', '-' }}-{{ foreach.item[3] | replace: ' ', '-' }}"
+            per_page: 1
+          headers:
+            kbn-xsrf: "true"
+        on-failure:
+          continue: true
+
+      # _find returns { total, data }; skip create when GET succeeded and total >= 1 (item already exists).
+      - name: create_only_if_missing
+        type: if
+        condition: "not steps.get_exception.error: * and steps.get_exception.output.total >= 1"
+        steps:
+          - name: log_already_exists
+            type: console
+            with:
+              message: "Exception already exists for rule {{ foreach.item[0] }}, version {{ foreach.item[1] }}, namespace {{ foreach.item[2] }}, os {{ foreach.item[3] }} (row {{ foreach.index }}), skipping."
+        else:
+          - name: create_endpoint_exception
+            type: kibana.request
+            with:
+              method: POST
+              path: "/api/endpoint_list/items"
+              headers:
+                kbn-xsrf: "true"
+              body:
+                name: "Tune: {{ foreach.item[0] }} | {{ foreach.item[1] }} | {{ foreach.item[2] }} | {{ foreach.item[3] }}"
+                item_id: "tune-{{ foreach.item[0] | replace: ' ', '-' }}-{{ foreach.item[1] | replace: ' ', '-' }}-{{ foreach.item[2] | replace: ' ', '-' }}-{{ foreach.item[3] | replace: ' ', '-' }}"
+                description: "Added by workflow Disable Faulty Endpoint Rules from ES|QL. rule.name + policy version + data_stream.namespace + host.os.type (noisy-alert query)."
+                type: "simple"
+                namespace_type: "agnostic"
+                list_id: "endpoint_list"
+                os_types:
+                  - "{{ foreach.item[3] | downcase }}"
+                entries:
+                  - field: "rule.name"
+                    type: "match"
+                    operator: "included"
+                    value: "{{ foreach.item[0] }}"
+                  - field: "Endpoint.policy.applied.artifacts.global.version"
+                    type: "match"
+                    operator: "included"
+                    value: "{{ foreach.item[1] }}"
+                  - field: "data_stream.namespace"
+                    type: "match"
+                    operator: "included"
+                    value: "{{ foreach.item[2] }}"
+
+          - name: log_created
+            type: console
+            with:
+              message: "Exception created for rule {{ foreach.item[0] }}, version {{ foreach.item[1] }}, namespace {{ foreach.item[2] }}, os {{ foreach.item[3] }} (row {{ foreach.index }})."
+
+  - name: log_summary
+    type: console
+    with:
+      message: |
+        Processed {{ steps.run_esql.output.values | size }} row(s). Exceptions created or skipped (409 = already exists). Check Security → Exceptions → Endpoint Security Exception List.

--- a/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
+++ b/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
@@ -15,7 +15,8 @@
 #    [2] data_stream.namespace, [3] host.os.type
 # 2. For each row, creates one Endpoint Security Exception (if not already
 #    present): rule.name + policy version + namespace + os_types from
-#    host.os.type. Deterministic item_id (409 = skip).
+#    host.os.type. Deterministic item_id (+ sanitized to -); lookup by item_id,
+#    create skips on 409 if already exists.
 #
 # Schedule: every 31 minutes (manual trigger also available).
 #
@@ -24,6 +25,8 @@
 #   https://github.com/elastic/protections-artifacts/tree/main/behavior
 # - Endpoint Security Exception List: Security -> Rules -> Shared exception
 #   lists -> Endpoint Security Exception List
+# - Exception list item lookup (by sanitized item_id; + in version → -):
+#   GET /api/exception_lists/items?item_id=tune-...&list_id=endpoint_list&namespace_type=agnostic
 # - https://www.elastic.co/docs/solutions/security/detect-and-alert/add-manage-exceptions
 # =============================================================================
 version: "1"
@@ -76,19 +79,21 @@ steps:
         type: kibana.request
         with:
           method: GET
-          path: "/api/endpoint_list/items/_find"
+          # Lookup by item_id (must match create: spaces and + → -). _find filters are brittle.
+          path: "/api/exception_lists/items"
           query:
-            filter: "item_id:tune-{{ foreach.item[0] | replace: ' ', '-' }}-{{ foreach.item[1] | replace: ' ', '-' }}-{{ foreach.item[2] | replace: ' ', '-' }}-{{ foreach.item[3] | replace: ' ', '-' }}"
-            per_page: 1
+            item_id: "tune-{{ foreach.item[0] | replace: ' ', '-' | replace: '+', '-' }}-{{ foreach.item[1] | replace: ' ', '-' | replace: '+', '-' }}-{{ foreach.item[2] | replace: ' ', '-' | replace: '+', '-' }}-{{ foreach.item[3] | replace: ' ', '-' | replace: '+', '-' }}"
+            list_id: "endpoint_list"
+            namespace_type: "agnostic"
           headers:
             kbn-xsrf: "true"
         on-failure:
           continue: true
 
-      # _find returns { total, data }; skip create when GET succeeded and total >= 1 (item already exists).
+      # 200 = item exists (skip). 404 = not found (create). POST 409 also treated as skip.
       - name: create_only_if_missing
         type: if
-        condition: "not steps.get_exception.error: * and steps.get_exception.output.total >= 1"
+        condition: "not steps.get_exception.error: *"
         steps:
           - name: log_already_exists
             type: console
@@ -104,7 +109,7 @@ steps:
                 kbn-xsrf: "true"
               body:
                 name: "Tune: {{ foreach.item[0] }} | {{ foreach.item[1] }} | {{ foreach.item[2] }} | {{ foreach.item[3] }}"
-                item_id: "tune-{{ foreach.item[0] | replace: ' ', '-' }}-{{ foreach.item[1] | replace: ' ', '-' }}-{{ foreach.item[2] | replace: ' ', '-' }}-{{ foreach.item[3] | replace: ' ', '-' }}"
+                item_id: "tune-{{ foreach.item[0] | replace: ' ', '-' | replace: '+', '-' }}-{{ foreach.item[1] | replace: ' ', '-' | replace: '+', '-' }}-{{ foreach.item[2] | replace: ' ', '-' | replace: '+', '-' }}-{{ foreach.item[3] | replace: ' ', '-' | replace: '+', '-' }}"
                 description: "Added by workflow Disable Noisy Elastic Defend Behavior Rules from ES|QL. rule.name + policy version + data_stream.namespace + host.os.type (noisy-alert query)."
                 type: "simple"
                 namespace_type: "agnostic"
@@ -124,11 +129,13 @@ steps:
                     type: "match"
                     operator: "included"
                     value: "{{ foreach.item[2] }}"
+            on-failure:
+              continue: true
 
           - name: log_created
             type: console
             with:
-              message: "Exception created for rule {{ foreach.item[0] }}, version {{ foreach.item[1] }}, namespace {{ foreach.item[2] }}, os {{ foreach.item[3] }} (row {{ foreach.index }})."
+              message: "{% if steps.create_endpoint_exception.error %}{% if steps.create_endpoint_exception.error.message contains '409' or steps.create_endpoint_exception.error.message contains 'already exists' %}Exception already exists for rule {{ foreach.item[0] }}, version {{ foreach.item[1] }}, namespace {{ foreach.item[2] }}, os {{ foreach.item[3] }} (row {{ foreach.index }}), skipping.{% else %}Failed to create exception for rule {{ foreach.item[0] }}, version {{ foreach.item[1] }}, namespace {{ foreach.item[2] }}, os {{ foreach.item[3] }} (row {{ foreach.index }}): {{ steps.create_endpoint_exception.error }}{% endif %}{% else %}Exception created for rule {{ foreach.item[0] }}, version {{ foreach.item[1] }}, namespace {{ foreach.item[2] }}, os {{ foreach.item[3] }} (row {{ foreach.index }}).{% endif %}"
 
   - name: log_summary
     type: console

--- a/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
+++ b/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
@@ -1,16 +1,16 @@
 # =============================================================================
-# Workflow: Disable Faulty Endpoint Rules from ES|QL
+# Workflow: Disable Noisy Elastic Defend Behavior Rules from ES|QL
 # Category: security/detection
 #
 # Detects noisy Elastic Defend behavior rules (FP bursts across many hosts and
 # processes) via ES|QL and auto-creates scoped Endpoint Security
 # exceptions per rule name, policy artifact version, data_stream.namespace,
-# and host.os.type. Remediates the faulty rule version without blocking
+# and host.os.type. Remediates the noisy rule version without blocking
 # future artifact updates — a new policy version runs normally and is not
 # covered by existing exceptions.
 #
 # 1. Runs an ES|QL query that finds rules firing on many hosts and many
-#    distinct processes (likely faulty / noisy rules). Query returns at least:
+#    distinct processes (likely noisy rules). Query returns at least:
 #    [0] rule.name, [1] Endpoint.policy.applied.artifacts.global.version,
 #    [2] data_stream.namespace, [3] host.os.type
 # 2. For each row, creates one Endpoint Security Exception (if not already
@@ -20,16 +20,18 @@
 # Schedule: every 31 minutes (manual trigger also available).
 #
 # References:
+# - Elastic Defend behavior rules (protections artifacts):
+#   https://github.com/elastic/protections-artifacts/tree/main/behavior
 # - Endpoint Security Exception List: Security -> Rules -> Shared exception
 #   lists -> Endpoint Security Exception List
 # - https://www.elastic.co/docs/solutions/security/detect-and-alert/add-manage-exceptions
 # =============================================================================
 version: "1"
-name: Disable Faulty Endpoint Behavior Rules
+name: Disable Noisy Elastic Defend Behavior Rules
 description: |
-  Detect noisy Defend rules via ES|QL and create scoped Endpoint exceptions
-  (rule.name + policy version + namespace + OS). Skips if already present.
-  Remediates FP bursts by rule version; new artifact versions are unaffected.
+  Detect noisy Elastic Defend behavior rules via ES|QL and create scoped Endpoint
+  exceptions (rule.name + policy version + namespace + OS). Skips if already
+  present. Remediates FP bursts by rule version; new artifact versions are unaffected.
 enabled: true
 tags:
   - security
@@ -107,7 +109,7 @@ steps:
               body:
                 name: "Tune: {{ foreach.item[0] }} | {{ foreach.item[1] }} | {{ foreach.item[2] }} | {{ foreach.item[3] }}"
                 item_id: "tune-{{ foreach.item[0] | replace: ' ', '-' }}-{{ foreach.item[1] | replace: ' ', '-' }}-{{ foreach.item[2] | replace: ' ', '-' }}-{{ foreach.item[3] | replace: ' ', '-' }}"
-                description: "Added by workflow Disable Faulty Endpoint Rules from ES|QL. rule.name + policy version + data_stream.namespace + host.os.type (noisy-alert query)."
+                description: "Added by workflow Disable Noisy Elastic Defend Behavior Rules from ES|QL. rule.name + policy version + data_stream.namespace + host.os.type (noisy-alert query)."
                 type: "simple"
                 namespace_type: "agnostic"
                 list_id: "endpoint_list"

--- a/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
+++ b/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
@@ -60,7 +60,7 @@ triggers:
           | STATS BY rule.name, Endpoint.policy.applied.artifacts.global.version, data_stream.namespace, host.os.type
   - type: scheduled
     with:
-      every: 31m
+      every: 15m
 
 # -----------------------------------------------------------------------------
 # STEPS

--- a/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
+++ b/examples/security/detection/disable-noisy-endpoint-rules-from-esql.yaml
@@ -40,25 +40,21 @@ tags:
   - detection
 
 # -----------------------------------------------------------------------------
-# INPUTS
-# -----------------------------------------------------------------------------
-inputs:
-  - name: esql_query
-    type: string
-    description: ES|QL query. Columns [0] rule.name, [1] Endpoint.policy.applied.artifacts.global.version, [2] data_stream.namespace, [3] host.os.type.
-    required: true
-    default: |
-      FROM logs-endpoint.alerts*
-      | WHERE @timestamp > NOW() - 30 minute and rule.name is not null and event.code == "behavior" and process.code_signature.trusted == true and process.parent.code_signature.trusted == true
-      | STATS alerts_count = COUNT(*), host_count = COUNT_DISTINCT(host.id), proc_count = COUNT_DISTINCT(process.name), parent_count = COUNT_DISTINCT(process.parent.name) BY rule.name, Endpoint.policy.applied.artifacts.global.version, data_stream.namespace, host.os.type
-      | WHERE (host_count >= 5 and proc_count >= 3) or host_count >= 20
-      | STATS BY rule.name, Endpoint.policy.applied.artifacts.global.version, data_stream.namespace, host.os.type
-
-# -----------------------------------------------------------------------------
 # TRIGGERS — manual + every 31 minutes
 # -----------------------------------------------------------------------------
 triggers:
   - type: manual
+    inputs:
+      - name: esql_query
+        type: string
+        description: ES|QL query. Columns [0] rule.name, [1] Endpoint.policy.applied.artifacts.global.version, [2] data_stream.namespace, [3] host.os.type.
+        required: true
+        default: |
+          FROM logs-endpoint.alerts*
+          | WHERE @timestamp > NOW() - 30 minute and rule.name is not null and event.code == "behavior" and process.code_signature.trusted == true and process.parent.code_signature.trusted == true
+          | STATS alerts_count = COUNT(*), host_count = COUNT_DISTINCT(host.id), proc_count = COUNT_DISTINCT(process.name), parent_count = COUNT_DISTINCT(process.parent.name) BY rule.name, Endpoint.policy.applied.artifacts.global.version, data_stream.namespace, host.os.type
+          | WHERE (host_count >= 5 and proc_count >= 3) or host_count >= 20
+          | STATS BY rule.name, Endpoint.policy.applied.artifacts.global.version, data_stream.namespace, host.os.type
   - type: scheduled
     with:
       every: 31m


### PR DESCRIPTION
## Summary

Detects noisy Elastic Defend behavior rules (false-positive bursts across many hosts and processes) using ES|QL and automatically creates scoped Endpoint Security exceptions per `rule.name`, `Endpoint.policy.applied.artifacts.global.version`, `data_stream.namespace`, and `host.os.type`.

Exceptions are intentionally scoped to a specific policy artifact version, remediating only the faulty rule version without blocking future Endpoint policy updates. When a new policy artifact version is applied, existing exceptions no longer match and the updated rule runs normally.

### Implementation

* Runs an ES|QL query to identify behavior rules firing across many hosts and many distinct processes, indicating likely noisy or faulty rules.
* The query returns at least:

  * `rule.name`
  * `Endpoint.policy.applied.artifacts.global.version`
  * `data_stream.namespace`
  * `host.os.type`
* Creates one Endpoint Security Exception per unique result, scoped to the rule name, policy artifact version, namespace, and OS type.
* Uses a deterministic `item_id` to make exception creation idempotent. Existing exceptions (HTTP 409) are skipped.
* Supports both scheduled execution (every 31 minutes) and manual triggering.


Create new exception test:
<img width="1198" height="415" alt="image" src="https://github.com/user-attachments/assets/50ceef10-f1ac-460e-a7ff-b4cf52ba8249" />

<img width="1192" height="461" alt="image" src="https://github.com/user-attachments/assets/f7685eef-37ba-4a6e-94ef-423b5026f1ea" />


Skip if existing:
<img width="1194" height="454" alt="image" src="https://github.com/user-attachments/assets/b90f9b33-62d7-419b-a680-ebc20df57102" />