### PR TITLE
[New] Sync Rule Exceptions Across Spaces Workflow

### DIFF
--- a/examples/security/detection/README.md
+++ b/examples/security/detection/README.md
@@ -2,10 +2,11 @@
 
 Threat detection, alerting, and rule management workflows
 
-## Workflows (9)
+## Workflows (10)
 
 | Workflow | Description |
 |----------|-------------|
+| [Sync Rule Exceptions Across Spaces](./sync-rule-exceptions-across-spaces.yaml) | One-way sync of rule exceptions between Kibana spaces: exceptions added to any rule's default exception list in a source space (e.g. a "subset" space) are pushed to the matching rules (same rule_id) in a target space (e.g. the "main" space), skipping items already synced (optionally overwriting them when the source copy is newer). It is self-contained in Kibana, no external services |
 | [Disable Noisy Elastic Defend Behavior Rules](./disable-noisy-endpoint-rules-from-esql.yaml) | Detects noisy Elastic Defend behavior rules via ES\|QL (FP bursts) and auto-creates scoped Endpoint Security exceptions by rule version; new artifact versions are unaffected |
 | [␆ Mark Alert as Acknowledged](./mark-alert-as-acknowledged.yaml) | This workflow YAML defines a manual trigger for acknowledging security alerts |
 | [🏷️ Add Alert Tag - FP](./add-alert-tag-fp.yaml) | This workflow YAML defines a manual trigger for adding a tag to a security alert |

--- a/examples/security/detection/README.md
+++ b/examples/security/detection/README.md
@@ -6,7 +6,7 @@ Threat detection, alerting, and rule management workflows
 
 | Workflow | Description |
 |----------|-------------|
-| [Sync Rule Exceptions Across Spaces](./sync-rule-exceptions-across-spaces.yaml) | One-way sync of rule exceptions between Kibana spaces: exceptions added to any rule's default exception list in a source space (e.g. a "subset" space) are pushed to the matching rules (same rule_id) in a target space (e.g. the "main" space), skipping items already synced (optionally overwriting them when the source copy is newer). It is self-contained in Kibana, no external services |
+| [Sync Rule Exceptions Across Spaces](./sync-rule-exceptions-across-spaces.yaml) | One-way sync of rule exceptions between Kibana spaces: exceptions added to any rule's default exception list in a source space (e.g. a "subset" space) are pushed to the matching rules (same rule_id) in a target space (e.g. the "main" space), skipping items already synced, with opt-in consts to overwrite items when the source copy is newer and to delete workflow-pushed copies whose source exception was removed. It is self-contained in Kibana, no external services |
 | [Disable Noisy Elastic Defend Behavior Rules](./disable-noisy-endpoint-rules-from-esql.yaml) | Detects noisy Elastic Defend behavior rules via ES\|QL (FP bursts) and auto-creates scoped Endpoint Security exceptions by rule version; new artifact versions are unaffected |
 | [␆ Mark Alert as Acknowledged](./mark-alert-as-acknowledged.yaml) | This workflow YAML defines a manual trigger for acknowledging security alerts |
 | [🏷️ Add Alert Tag - FP](./add-alert-tag-fp.yaml) | This workflow YAML defines a manual trigger for adding a tag to a security alert |

--- a/examples/security/detection/sync-rule-exceptions-across-spaces.yaml
+++ b/examples/security/detection/sync-rule-exceptions-across-spaces.yaml
@@ -20,8 +20,8 @@
 #    default exception list (the list built by the rule's "Add rule
 #    exception" flow).
 # 2. For each such rule, read its default-list items, and resolve the
-#    matching rule (same rule_id) in the target space — rules with no items
-#    or no counterpart in the target space are skipped.
+#    matching rule (same rule_id) in the target space — rules with no
+#    counterpart in the target space are skipped.
 # 3. For each item, look it up by item_id in the target space; if missing,
 #    recreate it on the target rule via
 #    POST /api/detection_engine/rules/<id>/exceptions — this also creates
@@ -31,18 +31,28 @@
 #    overwrite_existing: true, it is overwritten (PUT) whenever the source
 #    copy was updated more recently than the target copy; with the default
 #    (false), existing items are never touched.
+# 5. With sync_deletions: true, items on the target rule's default list
+#    that this workflow previously pushed (recognized by their provenance
+#    comment) and that no longer exist on the source rule are deleted.
+#    Exceptions created directly in the target space carry no provenance
+#    comment and are never deleted.
 # Unchanged items are skipped (lookup by item_id, POST 409 also treated as
 # already-synced), so frequent runs are cheap, idempotent no-ops.
 #
 # Scope and caveats:
-# - One-way: source → target. Deletions are not synced — removing an item in
-#   the source space does not remove the copy already pushed to the target.
+# - One-way: source → target. Nothing is ever written to the source space.
 # - Edits sync only when overwrite_existing: true. Items are matched by
 #   item_id and compared by updated_at (source newer than target = push),
 #   so edits made directly to the target copy survive until the source item
 #   changes again — at which point the source version wins. With the
 #   default (false), items already pushed are never touched; delete the
 #   target copy to force a re-push.
+# - Deletions sync only when sync_deletions: true, and only for items the
+#   workflow itself pushed (identified by the provenance comment added on
+#   creation). Removing that comment from a target copy exempts it from
+#   deletion. When enabling this, keep the per_page caps above your real
+#   rule/item counts — a source item beyond the fetch cap would look
+#   deleted.
 # - Only rule default exception lists are synced. Space-bound shared
 #   exception lists attached to a rule are reported but not copied — for
 #   those, prefer a space-agnostic shared list (API-only to create), which
@@ -58,8 +68,8 @@
 # - Rule listing: GET /api/detection_engine/rules/_find
 # - Create rule exception items (creates the default list if needed):
 #   POST /api/detection_engine/rules/<rule UUID>/exceptions
-# - Exception list item lookup:
-#   GET /api/exception_lists/items?item_id=...&namespace_type=single
+# - Exception list item lookup / update / delete:
+#   GET|PUT|DELETE /api/exception_lists/items (item_id + namespace_type)
 # =============================================================================
 version: "1"
 name: Sync Rule Exceptions Across Spaces
@@ -69,8 +79,9 @@ description: |
   space) are pushed to the matching rule (same rule_id) in the target space
   (e.g. the "main" space). Items are matched by item_id, so re-runs skip
   anything already synced; with overwrite_existing: true, source edits
-  overwrite the target copy when the source item is newer. Shared exception
-  lists are reported but not copied.
+  overwrite the target copy when the source item is newer, and with
+  sync_deletions: true, workflow-pushed copies whose source item was removed
+  are deleted. Shared exception lists are reported but not copied.
 enabled: true
 tags:
   - security
@@ -90,6 +101,13 @@ consts:
   # target copy. When false (default), items already synced are never
   # touched.
   overwrite_existing: false
+  # --- Deletions: remove workflow-pushed copies whose source is gone ---------
+  # When true, items on a target rule's default list that were pushed by
+  # this workflow (recognized by their provenance comment) and no longer
+  # exist on the source rule are deleted. Exceptions created directly in
+  # the target space are never deleted. When false (default), nothing is
+  # ever deleted.
+  sync_deletions: false
 
 triggers:
   - type: manual
@@ -138,7 +156,8 @@ steps:
         condition: 'steps.set_rule_ctx.output.src_list_id: * AND not steps.set_rule_ctx.output.src_list_id: ""'
         steps:
           # per_page caps a single sync batch; raise it if a rule carries
-          # more than 500 exception items.
+          # more than 500 exception items. With sync_deletions enabled this
+          # cap matters doubly: a source item beyond it would look deleted.
           - name: get_source_items
             type: kibana.request
             with:
@@ -151,35 +170,37 @@ steps:
               headers:
                 kbn-xsrf: "true"
 
-          - name: if_items_found
-            type: if
-            condition: steps.get_source_items.output.total > 0
-            steps:
-              # The matching rule in the target space, by the same stable
-              # rule_id. A 404 surfaces as a step error, handled below.
-              - name: get_target_rule
-                type: kibana.request
-                with:
-                  method: GET
-                  path: "/s/{{ consts.target_space }}/api/detection_engine/rules"
-                  query:
-                    rule_id: "{{ steps.set_rule_ctx.output.rule_id }}"
-                  headers:
-                    kbn-xsrf: "true"
-                on-failure:
-                  continue: true
+          # The matching rule in the target space, by the same stable
+          # rule_id. Resolved even when the source list is empty — the
+          # deletion pass must still run after the last source item is
+          # removed. A 404 surfaces as a step error, handled below.
+          - name: get_target_rule
+            type: kibana.request
+            with:
+              method: GET
+              path: "/s/{{ consts.target_space }}/api/detection_engine/rules"
+              query:
+                rule_id: "{{ steps.set_rule_ctx.output.rule_id }}"
+              headers:
+                kbn-xsrf: "true"
+            on-failure:
+              continue: true
 
-              - name: if_target_rule_found
+          - name: if_target_rule_found
+            type: if
+            condition: "not steps.get_target_rule.error: *"
+            steps:
+              - name: if_items_found
                 type: if
-                condition: "not steps.get_target_rule.error: *"
+                condition: steps.get_source_items.output.total > 0
                 steps:
                   - name: per_item_sync
                     type: foreach
                     foreach: "{{ steps.get_source_items.output.data }}"
                     steps:
-                      # 200 = already synced (skip). 404 = missing (push).
-                      # item_id is preserved on push, so this lookup is the
-                      # idempotency check.
+                      # 200 = already synced (skip/overwrite). 404 = missing
+                      # (push). item_id is preserved on push, so this lookup
+                      # is the idempotency check.
                       - name: get_target_item
                         type: kibana.request
                         with:
@@ -253,7 +274,9 @@ steps:
                           # injects the real arrays; plain {{ }} renders to
                           # a string and the API rejects it with a 400.
                           # item_id is kept so future runs recognize the
-                          # copy.
+                          # copy, and the provenance comment marks it as
+                          # workflow-managed (the deletion pass relies on
+                          # it).
                           - name: create_target_item
                             type: kibana.request
                             with:
@@ -280,15 +303,77 @@ steps:
                             with:
                               message: "{% if steps.create_target_item.error %}{% if steps.create_target_item.error.message contains '409' or steps.create_target_item.error.message contains 'already exists' %}Exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) already exists in space \"{{ consts.target_space }}\", skipping.{% else %}Failed to push exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) to space \"{{ consts.target_space }}\": {{ steps.create_target_item.error }}{% endif %}{% else %}Pushed exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) to rule \"{{ steps.get_target_rule.output.name }}\" in space \"{{ consts.target_space }}\".{% endif %}"
 
-                  - name: log_rule_summary
-                    type: console
+              # Deletion pass: remove workflow-pushed copies whose source
+              # item is gone. Runs only with sync_deletions: true and only
+              # once the target rule has a default list to inspect.
+              - name: set_deletion_ctx
+                type: data.set
+                with:
+                  deletions_enabled: "{% if consts.sync_deletions %}true{% else %}false{% endif %}"
+                  tgt_list_id: "{%- for l in steps.get_target_rule.output.exceptions_list -%}{%- if l.type == 'rule_default' -%}{{ l.list_id }}{%- endif -%}{%- endfor -%}"
+                  source_item_ids: "{{ steps.get_source_items.output.data | map: 'item_id' | join: ',' }}"
+
+              - name: if_deletions_enabled
+                type: if
+                condition: 'steps.set_deletion_ctx.output.deletions_enabled: "true" AND steps.set_deletion_ctx.output.tgt_list_id: * AND not steps.set_deletion_ctx.output.tgt_list_id: ""'
+                steps:
+                  - name: get_target_items
+                    type: kibana.request
                     with:
-                      message: 'Rule "{{ steps.set_rule_ctx.output.rule_name }}" (rule_id {{ steps.set_rule_ctx.output.rule_id }}): {{ steps.get_source_items.output.total }} exception item(s) checked against space "{{ consts.target_space }}" (see per-item logs above).{% assign shared = steps.set_rule_ctx.output.shared_list_count | plus: 0 %}{% if shared > 0 %} Note: {{ shared }} space-bound shared exception list(s) attached to this rule were NOT synced — use space-agnostic shared lists for those.{% endif %}'
-                else:
-                  - name: log_target_missing
-                    type: console
-                    with:
-                      message: 'Rule "{{ steps.set_rule_ctx.output.rule_name }}" (rule_id {{ steps.set_rule_ctx.output.rule_id }}) has {{ steps.get_source_items.output.total }} exception item(s) in space "{{ consts.source_space }}" but no matching rule in space "{{ consts.target_space }}" — skipping. Install or create the rule there to sync it.'
+                      method: GET
+                      path: "/s/{{ consts.target_space }}/api/exception_lists/items/_find"
+                      query:
+                        list_id: "{{ steps.set_deletion_ctx.output.tgt_list_id }}"
+                        namespace_type: "single"
+                        per_page: "500"
+                      headers:
+                        kbn-xsrf: "true"
+
+                  - name: per_target_item_cleanup
+                    type: foreach
+                    foreach: "{{ steps.get_target_items.output.data }}"
+                    steps:
+                      # Delete only when BOTH hold: the item carries this
+                      # workflow's provenance comment (so it was pushed by
+                      # the sync, not created by an analyst in the target
+                      # space) AND its item_id is gone from the source
+                      # rule's list.
+                      - name: check_orphan
+                        type: data.set
+                        with:
+                          should_delete: "{%- assign managed = false -%}{%- for c in foreach.item.comments -%}{%- if c.comment contains 'Synced from space' -%}{%- assign managed = true -%}{%- endif -%}{%- endfor -%}{%- assign present = false -%}{%- assign ids = steps.set_deletion_ctx.output.source_item_ids | split: ',' -%}{%- for id in ids -%}{%- if id == foreach.item.item_id -%}{%- assign present = true -%}{%- endif -%}{%- endfor -%}{%- if managed and present == false -%}true{%- else -%}false{%- endif -%}"
+
+                      - name: if_orphaned_copy
+                        type: if
+                        condition: 'steps.check_orphan.output.should_delete: "true"'
+                        steps:
+                          - name: delete_target_item
+                            type: kibana.request
+                            with:
+                              method: DELETE
+                              path: "/s/{{ consts.target_space }}/api/exception_lists/items"
+                              query:
+                                item_id: "{{ foreach.item.item_id }}"
+                                namespace_type: "single"
+                              headers:
+                                kbn-xsrf: "true"
+                            on-failure:
+                              continue: true
+
+                          - name: log_deleted
+                            type: console
+                            with:
+                              message: "{% if steps.delete_target_item.error %}Failed to delete orphaned exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) from space \"{{ consts.target_space }}\": {{ steps.delete_target_item.error }}{% else %}Deleted exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) from space \"{{ consts.target_space }}\" — its source item was removed from space \"{{ consts.source_space }}\".{% endif %}"
+
+              - name: log_rule_summary
+                type: console
+                with:
+                  message: 'Rule "{{ steps.set_rule_ctx.output.rule_name }}" (rule_id {{ steps.set_rule_ctx.output.rule_id }}): {{ steps.get_source_items.output.total }} exception item(s) checked against space "{{ consts.target_space }}" (see per-item logs above).{% assign shared = steps.set_rule_ctx.output.shared_list_count | plus: 0 %}{% if shared > 0 %} Note: {{ shared }} space-bound shared exception list(s) attached to this rule were NOT synced — use space-agnostic shared lists for those.{% endif %}'
+            else:
+              - name: log_target_missing
+                type: console
+                with:
+                  message: 'Rule "{{ steps.set_rule_ctx.output.rule_name }}" (rule_id {{ steps.set_rule_ctx.output.rule_id }}) has {{ steps.get_source_items.output.total }} exception item(s) in space "{{ consts.source_space }}" but no matching rule in space "{{ consts.target_space }}" — skipping. Install or create the rule there to sync it.'
 
   - name: log_done
     type: console

--- a/examples/security/detection/sync-rule-exceptions-across-spaces.yaml
+++ b/examples/security/detection/sync-rule-exceptions-across-spaces.yaml
@@ -1,0 +1,296 @@
+# =============================================================================
+# Workflow: Sync Rule Exceptions Across Spaces
+# Category: security/detection
+#
+# Rule exceptions are space-dependent: an exception added to a rule in one
+# Kibana space does not apply to the "same" rule in another space. This
+# workflow keeps them in sync — one-way, for every rule in the source space:
+# exceptions added to any rule's default exception list in a source space
+# (e.g. a "subset" space covering only some logs) are pushed to the matching
+# rule in a target space (e.g. the "main" space covering all logs). Rules
+# are matched across spaces by their stable rule_id (identical in every
+# space for prebuilt rules).
+#
+# Entirely self-contained in Kibana (kibana.request against the detection
+# engine + exceptions APIs) — no GitHub, no detection-rules CLI, no external
+# connectors.
+#
+# On each run (scheduled + manual):
+# 1. List the rules in the source space and pick out those carrying a
+#    default exception list (the list built by the rule's "Add rule
+#    exception" flow).
+# 2. For each such rule, read its default-list items, and resolve the
+#    matching rule (same rule_id) in the target space — rules with no items
+#    or no counterpart in the target space are skipped.
+# 3. For each item, look it up by item_id in the target space; if missing,
+#    recreate it on the target rule via
+#    POST /api/detection_engine/rules/<id>/exceptions — this also creates
+#    the target rule's default exception list on first sync, so target
+#    rules need no manual preparation.
+# 4. If the item already exists in the target space: with
+#    overwrite_existing: true, it is overwritten (PUT) whenever the source
+#    copy was updated more recently than the target copy; with the default
+#    (false), existing items are never touched.
+# Unchanged items are skipped (lookup by item_id, POST 409 also treated as
+# already-synced), so frequent runs are cheap, idempotent no-ops.
+#
+# Scope and caveats:
+# - One-way: source → target. Deletions are not synced — removing an item in
+#   the source space does not remove the copy already pushed to the target.
+# - Edits sync only when overwrite_existing: true. Items are matched by
+#   item_id and compared by updated_at (source newer than target = push),
+#   so edits made directly to the target copy survive until the source item
+#   changes again — at which point the source version wins. With the
+#   default (false), items already pushed are never touched; delete the
+#   target copy to force a re-push.
+# - Only rule default exception lists are synced. Space-bound shared
+#   exception lists attached to a rule are reported but not copied — for
+#   those, prefer a space-agnostic shared list (API-only to create), which
+#   every space sees natively.
+# - Comments and expiration dates (expire_time) are not carried over; each
+#   pushed item gets a provenance comment recording where it came from.
+# - per_page caps a run at 500 rules and 500 items per rule; raise the
+#   respective query params if your source space exceeds them.
+#
+# References:
+# - Rule exceptions:
+#   https://www.elastic.co/docs/solutions/security/detect-and-alert/add-manage-exceptions
+# - Rule listing: GET /api/detection_engine/rules/_find
+# - Create rule exception items (creates the default list if needed):
+#   POST /api/detection_engine/rules/<rule UUID>/exceptions
+# - Exception list item lookup:
+#   GET /api/exception_lists/items?item_id=...&namespace_type=single
+# =============================================================================
+version: "1"
+name: Sync Rule Exceptions Across Spaces
+description: |
+  One-way sync of rule exceptions between Kibana spaces: exceptions added to
+  any rule's default exception list in the source space (e.g. a "subset"
+  space) are pushed to the matching rule (same rule_id) in the target space
+  (e.g. the "main" space). Items are matched by item_id, so re-runs skip
+  anything already synced; with overwrite_existing: true, source edits
+  overwrite the target copy when the source item is newer. Shared exception
+  lists are reported but not copied.
+enabled: true
+tags:
+  - security
+  - detection
+  - exceptions
+  - spaces
+  - automation
+
+consts:
+  # --- Space the exceptions are authored in (space ID, not display name) -----
+  source_space: "subset"
+  # --- Space the exceptions are pushed to ("default" is the initial space) ---
+  target_space: "default"
+  # --- Overwrite: push source edits over existing target copies --------------
+  # When true, an item that already exists in the target space is
+  # overwritten whenever the source copy was updated more recently than the
+  # target copy. When false (default), items already synced are never
+  # touched.
+  overwrite_existing: false
+
+triggers:
+  - type: manual
+  # Adjust the sync cadence here (consts cannot be referenced in triggers).
+  # Already-synced items are skipped, so frequent runs are cheap no-ops.
+  - type: scheduled
+    with:
+      every: 15m
+
+steps:
+  # All rules in the source space, including their exception list
+  # references. per_page caps a single sync batch; raise it if the space
+  # holds more than 500 rules.
+  - name: get_source_rules
+    type: kibana.request
+    with:
+      method: GET
+      path: "/s/{{ consts.source_space }}/api/detection_engine/rules/_find"
+      query:
+        per_page: "500"
+      headers:
+        kbn-xsrf: "true"
+
+  - name: per_rule_sync
+    type: foreach
+    foreach: "{{ steps.get_source_rules.output.data }}"
+    steps:
+      # Capture the rule's context: the inner per-item foreach shadows
+      # foreach.item, so anything from the rule is referenced through this
+      # step. Picks the default exception list (type rule_default) and
+      # counts space-bound shared lists so the per-rule summary can flag
+      # them (they are not synced).
+      - name: set_rule_ctx
+        type: data.set
+        with:
+          rule_id: "{{ foreach.item.rule_id }}"
+          rule_name: "{{ foreach.item.name }}"
+          src_list_id: "{%- for l in foreach.item.exceptions_list -%}{%- if l.type == 'rule_default' -%}{{ l.list_id }}{%- endif -%}{%- endfor -%}"
+          src_namespace: "{%- for l in foreach.item.exceptions_list -%}{%- if l.type == 'rule_default' -%}{{ l.namespace_type }}{%- endif -%}{%- endfor -%}"
+          shared_list_count: "{%- assign n = 0 -%}{%- for l in foreach.item.exceptions_list -%}{%- if l.type != 'rule_default' and l.namespace_type == 'single' -%}{%- assign n = n | plus: 1 -%}{%- endif -%}{%- endfor -%}{{ n }}"
+
+      # Rules without a default exception list (the vast majority) are
+      # skipped without logging to keep the execution log readable.
+      - name: if_rule_has_default_list
+        type: if
+        condition: 'steps.set_rule_ctx.output.src_list_id: * AND not steps.set_rule_ctx.output.src_list_id: ""'
+        steps:
+          # per_page caps a single sync batch; raise it if a rule carries
+          # more than 500 exception items.
+          - name: get_source_items
+            type: kibana.request
+            with:
+              method: GET
+              path: "/s/{{ consts.source_space }}/api/exception_lists/items/_find"
+              query:
+                list_id: "{{ steps.set_rule_ctx.output.src_list_id }}"
+                namespace_type: "{{ steps.set_rule_ctx.output.src_namespace }}"
+                per_page: "500"
+              headers:
+                kbn-xsrf: "true"
+
+          - name: if_items_found
+            type: if
+            condition: steps.get_source_items.output.total > 0
+            steps:
+              # The matching rule in the target space, by the same stable
+              # rule_id. A 404 surfaces as a step error, handled below.
+              - name: get_target_rule
+                type: kibana.request
+                with:
+                  method: GET
+                  path: "/s/{{ consts.target_space }}/api/detection_engine/rules"
+                  query:
+                    rule_id: "{{ steps.set_rule_ctx.output.rule_id }}"
+                  headers:
+                    kbn-xsrf: "true"
+                on-failure:
+                  continue: true
+
+              - name: if_target_rule_found
+                type: if
+                condition: "not steps.get_target_rule.error: *"
+                steps:
+                  - name: per_item_sync
+                    type: foreach
+                    foreach: "{{ steps.get_source_items.output.data }}"
+                    steps:
+                      # 200 = already synced (skip). 404 = missing (push).
+                      # item_id is preserved on push, so this lookup is the
+                      # idempotency check.
+                      - name: get_target_item
+                        type: kibana.request
+                        with:
+                          method: GET
+                          path: "/s/{{ consts.target_space }}/api/exception_lists/items"
+                          query:
+                            item_id: "{{ foreach.item.item_id }}"
+                            namespace_type: "single"
+                          headers:
+                            kbn-xsrf: "true"
+                        on-failure:
+                          continue: true
+
+                      - name: create_only_if_missing
+                        type: if
+                        condition: "not steps.get_target_item.error: *"
+                        steps:
+                          # The item already exists in the target space.
+                          # Overwrite it only when overwrite_existing is
+                          # enabled AND the source copy is newer than the
+                          # target copy (ISO-8601 UTC timestamps compare
+                          # correctly as strings). The initial push always
+                          # leaves the target copy newer, so steady-state
+                          # runs stay no-ops.
+                          - name: check_item_changed
+                            type: data.set
+                            with:
+                              needs_update: "{% if consts.overwrite_existing and foreach.item.updated_at > steps.get_target_item.output.updated_at %}true{% else %}false{% endif %}"
+
+                          - name: if_source_newer
+                            type: if
+                            condition: 'steps.check_item_changed.output.needs_update: "true"'
+                            steps:
+                              # Same typed ${{ }} handling as the create.
+                              # comments are omitted so the target copy's
+                              # existing comments (incl. the provenance
+                              # note) are preserved.
+                              - name: update_target_item
+                                type: kibana.request
+                                with:
+                                  method: PUT
+                                  path: "/s/{{ consts.target_space }}/api/exception_lists/items"
+                                  headers:
+                                    kbn-xsrf: "true"
+                                  body:
+                                    item_id: "{{ foreach.item.item_id }}"
+                                    namespace_type: "single"
+                                    name: "{{ foreach.item.name }}"
+                                    description: "{{ foreach.item.description }}"
+                                    type: "{{ foreach.item.type }}"
+                                    entries: ${{ foreach.item.entries }}
+                                    os_types: ${{ foreach.item.os_types }}
+                                    tags: ${{ foreach.item.tags }}
+                                on-failure:
+                                  continue: true
+
+                              - name: log_updated
+                                type: console
+                                with:
+                                  message: "{% if steps.update_target_item.error %}Failed to overwrite exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) in space \"{{ consts.target_space }}\": {{ steps.update_target_item.error }}{% else %}Overwrote exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) in space \"{{ consts.target_space }}\" with the newer source version.{% endif %}"
+                            else:
+                              - name: log_already_synced
+                                type: console
+                                with:
+                                  message: 'Exception "{{ foreach.item.name }}" (item_id {{ foreach.item.item_id }}) already exists in space "{{ consts.target_space }}" — {% if consts.overwrite_existing %}up to date (source not newer), skipping{% else %}skipping (set overwrite_existing: true in consts to push source edits){% endif %}.'
+                        else:
+                          # Recreates the item on the target rule's default
+                          # exception list (creating that list on first
+                          # sync). entries/os_types/tags pass through
+                          # unchanged — note the typed ${{ }} syntax, which
+                          # injects the real arrays; plain {{ }} renders to
+                          # a string and the API rejects it with a 400.
+                          # item_id is kept so future runs recognize the
+                          # copy.
+                          - name: create_target_item
+                            type: kibana.request
+                            with:
+                              method: POST
+                              path: "/s/{{ consts.target_space }}/api/detection_engine/rules/{{ steps.get_target_rule.output.id }}/exceptions"
+                              headers:
+                                kbn-xsrf: "true"
+                              body:
+                                items:
+                                  - item_id: "{{ foreach.item.item_id }}"
+                                    name: "{{ foreach.item.name }}"
+                                    description: "{{ foreach.item.description }}"
+                                    type: "{{ foreach.item.type }}"
+                                    entries: ${{ foreach.item.entries }}
+                                    os_types: ${{ foreach.item.os_types }}
+                                    tags: ${{ foreach.item.tags }}
+                                    comments:
+                                      - comment: 'Synced from space "{{ consts.source_space }}" (rule_id {{ steps.set_rule_ctx.output.rule_id }}) by workflow "Sync Rule Exceptions Across Spaces", execution {{ execution.id }}.'
+                            on-failure:
+                              continue: true
+
+                          - name: log_pushed
+                            type: console
+                            with:
+                              message: "{% if steps.create_target_item.error %}{% if steps.create_target_item.error.message contains '409' or steps.create_target_item.error.message contains 'already exists' %}Exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) already exists in space \"{{ consts.target_space }}\", skipping.{% else %}Failed to push exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) to space \"{{ consts.target_space }}\": {{ steps.create_target_item.error }}{% endif %}{% else %}Pushed exception \"{{ foreach.item.name }}\" (item_id {{ foreach.item.item_id }}) to rule \"{{ steps.get_target_rule.output.name }}\" in space \"{{ consts.target_space }}\".{% endif %}"
+
+                  - name: log_rule_summary
+                    type: console
+                    with:
+                      message: 'Rule "{{ steps.set_rule_ctx.output.rule_name }}" (rule_id {{ steps.set_rule_ctx.output.rule_id }}): {{ steps.get_source_items.output.total }} exception item(s) checked against space "{{ consts.target_space }}" (see per-item logs above).{% assign shared = steps.set_rule_ctx.output.shared_list_count | plus: 0 %}{% if shared > 0 %} Note: {{ shared }} space-bound shared exception list(s) attached to this rule were NOT synced — use space-agnostic shared lists for those.{% endif %}'
+                else:
+                  - name: log_target_missing
+                    type: console
+                    with:
+                      message: 'Rule "{{ steps.set_rule_ctx.output.rule_name }}" (rule_id {{ steps.set_rule_ctx.output.rule_id }}) has {{ steps.get_source_items.output.total }} exception item(s) in space "{{ consts.source_space }}" but no matching rule in space "{{ consts.target_space }}" — skipping. Install or create the rule there to sync it.'
+
+  - name: log_done
+    type: console
+    with:
+      message: 'Rule exception sync finished: checked {{ steps.get_source_rules.output.total }} rule(s) in space "{{ consts.source_space }}" against space "{{ consts.target_space }}"{% if steps.get_source_rules.output.total > 500 %} (only the first 500 were processed this run — raise per_page in get_source_rules){% endif %}. execution.id={{ execution.id }}'


### PR DESCRIPTION
## Summary

Adds a new workflow called `sync-rule-exceptions-across-spaces`, a one-way sync of rule exceptions between Kibana spaces. Exceptions added to any rule's default exception list in a source space (e.g. a "subset" space covering only some logs) are automatically pushed to the matching rules in a target space (e.g. the "main" space covering all logs). No per-rule configuration is needed. Every rule in the source space is checked on each run, and rules are matched across spaces by their stable `rule_id` (identical in every space for prebuilt rules).

This addresses a common ask: detection rules are duplicated across spaces, but rule exceptions are space-dependent. An exception added in one space does not apply to the "same" rule in another. There is no native way to sync them, and the everyday analyst flows (the rule's "Add rule exception" button, UI-created shared exception lists) always produce space-bound objects.

The workflow is entirely self-contained in Kibana. `kibana.request` steps against the detection engine and exceptions APIs only. No GitHub, no detection-rules DaC CLI, no external connectors, and nothing to install outside the Workflows app.

On each run (every 15 minutes, plus manual):

1. Lists the rules in the source space and picks out those carrying a default exception list (the list built by the rule's "Add rule exception" flow); the rest are skipped silently.
2. For each such rule, reads its default-list items and resolves the matching rule (same `rule_id`) in the target space. Rules with no items, or with no counterpart in the target space, are skipped with a log line.
3. For each item, checks the target space by `item_id`; missing items are recreated on the target rule via `POST /api/detection_engine/rules/<id>/exceptions`, which also creates the target rule's default exception list on first sync. Target rules need no manual preparation.
4. For items that already exist in the target space: with `overwrite_existing: true`, the target copy is overwritten whenever the source copy was updated more recently; with the default (`false`), existing items are never touched.
5. With `sync_deletions: true`, items on the target rule's default list that the workflow previously pushed (recognized by their provenance comment) and that no longer exist on the source rule are deleted. Exceptions created directly in the target space carry no provenance comment and are never deleted.

Items keep their `item_id` and get a provenance comment recording the source space, rule, and workflow execution, so re-runs are cheap, idempotent no-ops (lookup by `item_id`, POST 409 treated as already-synced, overwrites only when the source is newer).

Configuration is four `consts`: `source_space` and `target_space` (space IDs), plus `overwrite_existing` (default `false`) to opt in to pushing source edits over already-synced items and `sync_deletions` (default `false`) to opt in to propagating deletions.

Space-bound shared exception lists attached to a source rule are detected and flagged in the run log rather than copied. For those, a space-agnostic shared list (`namespace_type: agnostic`, API-only to create) is the native cross-space mechanism and every space sees it without syncing.

> [!NOTE]
> The sync is one-way, and edits/deletions are opt-in. Edits propagate only when `overwrite_existing: true` (items are matched by `item_id` and compared by `updated_at`. The source version wins when it is newer, replacing any direct edits made to the target copy); with the default (`false`), already-synced items are never touched. Deletions propagate only when `sync_deletions: true`, and only for workflow-pushed copies. Items are identified by the provenance comment added on creation, so exceptions created directly in the target space are never deleted (and removing that comment from a copy exempts it). Comments and `expire_time` are not carried over. Only rule default exception lists are synced; a single run handles up to 500 rules and 500 items per rule (`per_page`, adjustable). With `sync_deletions` enabled, keep those caps above your real counts, since a source item beyond the fetch cap would look deleted.

## Testing

#### Sync

Pre-run
<img width="1898" height="970" alt="Screenshot from 2026-07-20 13-39-18" src="https://github.com/user-attachments/assets/b4a49606-4368-4a9b-806a-db4744eb97c6" />

Run
<img width="1898" height="970" alt="Screenshot from 2026-07-20 13-47-33" src="https://github.com/user-attachments/assets/f69a8d08-ab6a-4d48-89fa-9b960923116b" />


Post-run
<img width="1898" height="970" alt="Screenshot from 2026-07-20 13-46-48" src="https://github.com/user-attachments/assets/81460d5c-25a4-404b-9285-4811d76c31e6" />

 #### Sync with overwrite
 
 Pre-run
 <img width="1898" height="970" alt="Screenshot from 2026-07-20 13-48-55" src="https://github.com/user-attachments/assets/0731a274-634e-460b-a68c-bb2ccbc15c52" />

Post-run
<img width="1898" height="970" alt="Screenshot from 2026-07-20 13-54-54" src="https://github.com/user-attachments/assets/f11be48a-7a04-4827-a20c-0daedfbd33ed" />



#### Deletion 

<img width="1918" height="970" alt="test_delete_workflow" src="https://github.com/user-attachments/assets/41b36d53-d1f0-47d7-b825-02af47b96a8d" />
