### PR TITLE
[Library] Create template skill

### DIFF
--- a/.agents/skills/create-library-template/SKILL.md
+++ b/.agents/skills/create-library-template/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-library-template
-description: Author or modify a Workflow Template Library template (library/workflows/<slug>/<slug>.yaml). Use when creating a new workflow template, adding a workflow to the library, migrating an example to a template, editing a template-metadata block or install.form, fixing __install__ placeholders, or preparing a template PR for elastic/workflows.
+description: Author or modify a Workflow Template Library template. Use when creating a template, migrating an example to a template, editing template-metadata or install.form, or preparing a template PR.
 ---
 
 # Create a Workflow Template Library template

--- a/.agents/skills/create-library-template/SKILL.md
+++ b/.agents/skills/create-library-template/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: create-library-template
+description: Author or modify a Workflow Template Library template (library/workflows/<slug>/<slug>.yaml). Use when creating a new workflow template, adding a workflow to the library, migrating an example to a template, editing a template-metadata block or install.form, fixing __install__ placeholders, or preparing a template PR for elastic/workflows.
+---
+
+# Create a Workflow Template Library template
+
+## Where the rules are
+
+**Read [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) § "Authoring a template" before writing anything — do not work from memory.** It is the single source of truth for the file layout, the `template-metadata` block, the categories vocabulary (`library/categories.yaml`), `install.form` and how `__install__.*` references render (the most common source of broken templates), step-type rules, and style. Local validation and the PR checklist are in § "Validating locally" and § "Pull request flow" of the same file.
+
+Templates live at `library/workflows/<slug>/<slug>.yaml` — one directory per slug; directory, file name, and `template-metadata.slug` must match.
+
+## Migration references
+
+Some templates were migrated from a plain workflow in `examples/`. Study a pair or two before authoring — the diff shows exactly what "templatizing" means (add the `template-metadata` block, promote operator-specific values and connector ids to `install.form`, drop banner comments, tidy step comments):
+
+| Template (`library/workflows/`) | Original example (`examples/`) |
+|---|---|
+| `create-slack-channel/create-slack-channel.yaml` | `integrations/slack/create-slack-channel.yaml` |
+| `hash-threat-check/hash-threat-check.yaml` | `security/detection/hash-threat-check.yaml` |
+| `ip-reputation-check/ip-reputation-check.yaml` | `security/enrichment/ip-reputation-check.yaml` |
+| `mark-alert-as-acknowledged/mark-alert-as-acknowledged.yaml` | `security/detection/mark-alert-as-acknowledged.yaml` |
+| `root-cause-analysis/root-cause-analysis.yaml` | `observability/root-cause-analysis-rca-workflow.yaml` |
+| `semantic-knowledge-search/semantic-knowledge-search.yaml` | `search/semantic-knowledge-search.yaml` |
+| `web-search/web-search.yaml` | `search/web-search.yaml` |
+
+`ip-reputation-check` is the golden example referenced throughout CONTRIBUTING.md.
+
+## Workflow
+
+1. Read the CONTRIBUTING.md sections above.
+2. Pick the closest migration pair from the table and mirror its structure.
+3. Author the template; follow every rule in § "Authoring a template" (especially the `__install__.*` rendering rules).
+4. Validate per § "Validating locally" and open the PR per § "Pull request flow", including the validation output and a test plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# elastic/workflows — agent instructions
+
+This repository holds the **Workflow Template Library** content published to the CDN consumed by Kibana's Workflows app, plus a library of plain workflow examples.
+
+## Where things are
+
+- `library/workflows/<slug>/<slug>.yaml` — the installable **templates** (workflow YAML + `template-metadata` block).
+- `library/categories.yaml` — the closed category vocabulary templates may use.
+- `examples/` — plain **workflow examples** (no template metadata), organized by solution and integration.
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — the authoring guide for templates: metadata block, `install.form` / `__install__.*` rendering rules, style, local validation, and PR flow. **Read "Authoring a template" before creating or editing any template.**
+- [`.agents/skills/create-library-template/SKILL.md`](./.agents/skills/create-library-template/SKILL.md) — agent checklist for authoring a template, with example→template migration references.
+- `scripts/build-catalog.mjs` (`npm run build:catalog`) — catalog generator and the only local validation available today; usage and env-var overrides in CONTRIBUTING.md § "Validating locally".
+- `.buildkite/` — the (pending) catalog publish pipeline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,43 @@ If your template genuinely needs a category that is not in the vocab, **add the 
 
 When the operator installs a template into their Kibana, the catalog UI renders an install form derived from `template-metadata.install.form`. Whatever values the user submits get substituted into the workflow body wherever it references `__install__.<name>`.
 
-Two rules to internalize:
+Three rules to internalize:
 
 1. **`install.form` is the single source of truth.** Every `__install__.<name>` reference in the body MUST have a matching entry in `install.form`. The installer does not auto-derive form fields from `consts:` or anywhere else; an undeclared reference fails the install.
 2. **Form field names are kebab-case by convention** (e.g. `abuseipdb-connector`, `max-age-in-days`). They are internal template identifiers and are substituted away during rendering — end users never see them in the final workflow YAML.
+3. **References are plain text substitution — never wrap them in `{{ }}`.** See the next section; this is the most common authoring mistake.
+
+#### How `__install__.*` references render
+
+Substitution is **textual and happens once, at install time — before the workflow ever runs**. The installer replaces every `__install__.<name>` occurrence in the body with the submitted value. Liquid (`{{ ... }}`) is a **runtime** templating layer evaluated on each execution against the run context (`consts`, `inputs`, `steps.*`); install fields do not exist in that context.
+
+Therefore, **never wrap an install reference in Liquid braces**:
+
+```yaml
+# ❌ WRONG — after install this becomes path: "/_ml/jobs/{{ my-job }}/_forecast",
+# and at runtime Liquid resolves `my-job` as a (nonexistent) variable → empty string.
+path: "/_ml/jobs/{{ __install__.job-id }}/_forecast"
+
+# ✅ Bare reference — interpolated as text at install time.
+path: "/_ml/jobs/__install__.job-id/_forecast"
+```
+
+Bare references work as a whole scalar (`maxAgeInDays: __install__.max-age-in-days` — the value keeps its type), inline inside longer strings, and inside `|`/`>` block scalars.
+
+**Recommended pattern for anything used more than once (or embedded in strings): assign the install value to a const, then use normal Liquid on the const.** This gives the value a single, quote-safe injection point and keeps the body reading as ordinary workflow YAML:
+
+```yaml
+consts:
+  job_id: __install__.job-id        # snake_case! `{{ consts.job-id }}` would not parse in Liquid
+
+steps:
+  - name: run_forecast
+    type: elasticsearch.request
+    with:
+      path: "/_ml/anomaly_detectors/{{ consts.job_id }}/_forecast"
+```
+
+**Exception: `connector-id` always references the install field directly** (`connector-id: __install__.slack-connector`). It is resolved as a saved-object reference, not a Liquid-rendered value — this is the established pattern across all library templates.
 
 What belongs in the install form (vs `consts:`):
 
@@ -110,6 +143,7 @@ Templates that don't need any install-time inputs **omit the `install:` block en
 | `boolean` | Toggle | — |
 | `select` | Single choice from a fixed list | `options: [{ value, label }, ...]` |
 | `connector` | Picks an existing Kibana stack connector | `connectorType: .<vendor>` |
+| `esIndex` | An Elasticsearch index name | — (renders as a plain text input for now; index autocomplete is planned) |
 
 Every field can carry `label`, `description`, `required` (default `false`), and `default`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,12 +101,12 @@ Substitution is **textual and happens once, at install time — before the workf
 Therefore, **never wrap an install reference in Liquid braces**:
 
 ```yaml
-# ❌ WRONG — after install this becomes path: "/_ml/jobs/{{ my-job }}/_forecast",
+# ❌ WRONG — after install this becomes path: "/_ml/anomaly_detectors/{{ my-job }}/_forecast",
 # and at runtime Liquid resolves `my-job` as a (nonexistent) variable → empty string.
-path: "/_ml/jobs/{{ __install__.job-id }}/_forecast"
+path: "/_ml/anomaly_detectors/{{ __install__.job-id }}/_forecast"
 
 # ✅ Bare reference — interpolated as text at install time.
-path: "/_ml/jobs/__install__.job-id/_forecast"
+path: "/_ml/anomaly_detectors/__install__.job-id/_forecast"
 ```
 
 Bare references work as a whole scalar (`maxAgeInDays: __install__.max-age-in-days` — the value keeps its type), inline inside longer strings, and inside `|`/`>` block scalars.


### PR DESCRIPTION
## Summary

Improves agent/contributor guidance for authoring library templates, prompted by the `__install__.*`-in-Liquid-braces mistake in #22 (made even with AI assistance — the rules weren't discoverable anywhere in the repo).

- **`CONTRIBUTING.md`** — new "How `__install__.*` references render" section (install-time text substitution vs runtime Liquid, the `consts` indirection pattern, the `connector-id` exception) and adds the missing `esIndex` input type.
- **`.agents/skills/create-library-template/SKILL.md`** — new agent skill: points to the CONTRIBUTING.md rules (no duplication) and maps each library template to the `examples/` workflow it was migrated from, as authoring references.
- **`AGENTS.md`** — new repo map for agents (where templates, examples, rules, and validation live).
