### PR TITLE
Rename ai-agent category label to Agent Builder

### DIFF
--- a/library/categories.yaml
+++ b/library/categories.yaml
@@ -51,7 +51,7 @@ categories:
     name: "Search"
     description: "ES|QL, semantic search, knowledge retrieval workflows."
   - id: ai-agent
-    name: "AI agent"
+    name: "Agent Builder"
     description: "Agentic workflows, LLM-driven automation, tool calling."
   - id: integration
     name: "Integration"


### PR DESCRIPTION
## Summary
- Updates the `ai-agent` category `name` in `library/categories.yaml` from "AI agent" to "Agent Builder", matching the product name used in Kibana's Template library.
- Prepares the category vocabulary for upcoming Kibana plumbing that will read display labels from this source file instead of mechanically humanizing category ids (follow-up to [elastic/kibana#281590](https://github.com/elastic/kibana/pull/281590)).

## Test plan
- [x] `npm run build:catalog`
- [ ] Verify the `ai-agent` category name renders as "Agent Builder" once Kibana reads labels from `library/categories.yaml`


Made with [Cursor](https://cursor.com)