### PR TITLE
Add AWS OTel investigation templates (ALB, Lambda, RDS, SQS)

### DIFF
--- a/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
+++ b/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
@@ -309,8 +309,11 @@ steps:
                 crashing mid-request, or port not accepting).
               - target_tls_failure: target_tls_errors > 0 — backend TLS handshake failures
                 (cert expiry/mismatch on the target side).
-              - no_healthy_targets: elb_503 dominates and min_healthy is ~0 (or max_unhealthy
-                is the whole target group) — the ALB has nowhere to route.
+              - no_healthy_targets: elb_503 dominates and EITHER min_healthy is ~0, OR the
+                host-count metrics are entirely ABSENT during the window while they existed
+                before it (deregistered targets emit no host-count datapoints at all — a
+                scaled-to-zero service disappears from the metric rather than reading 0;
+                live-verified 2026-08-18) — the ALB has nowhere to route.
               - alb_capacity_pressure: rejected_connections > 0 — the ALB itself is refusing
                 connections (surge queue / connection limits), independent of target health.
               - alb_internal_5xx: elb_500 elevated with none of the above — an ALB-internal

--- a/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
+++ b/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
@@ -35,41 +35,31 @@ consts:
   baseline_lookend: "20 minutes"
   incident_lookback: "20 minutes"
 
-# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
-# from the alert payload in the `resolve` step below.
-inputs:
-  - name: load_balancer
-    type: string
-    description: >-
-      ApplicationELB dimension of the alerting ALB (e.g. app/fis-demo-fleet-alb/<id>).
-      Manual runs must supply it; alert-triggered runs derive it from the alert.
-    required: false
-  - name: service_name
-    type: string
-    description: >-
-      The service behind the ALB target group (e.g. gateway).
-    required: false
-  - name: alert_timestamp
-    type: string
-    description: >-
-      ISO8601 timestamp of the alert firing. Manual runs must supply it;
-      alert-triggered runs derive it from the alert.
-    required: false
-
 # The alert trigger fires only when a rule is connected to this workflow via the
 # "Run Workflow" rule action (.workflows system connector). Configure that action
 # with summaryMode:false so each run carries exactly ONE alert in event.alerts.
 triggers:
   - type: manual
+    inputs:
+      - name: load_balancer
+        type: string
+        description: >-
+          ApplicationELB dimension of the alerting ALB (e.g. app/fis-demo-fleet-alb/<id>).
+          Manual runs must supply it; alert-triggered runs derive it from the alert.
+        required: false
+      - name: service_name
+        type: string
+        description: >-
+          The service behind the ALB target group (e.g. gateway).
+        required: false
+      - name: alert_timestamp
+        type: string
+        description: >-
+          ISO8601 timestamp of the alert firing. Manual runs must supply it;
+          alert-triggered runs derive it from the alert.
+        required: false
   - type: alert
 
-# SPARSE-METRIC DISCIPLINE (learned on a live alert-triggered run): CloudWatch omits
-# zero-valued counters entirely, so a per-code or error-count field is UNMAPPED in
-# Elastic until the first such error ever occurs — and ES|QL fails verification on any
-# unknown column, killing the whole query. Therefore: the REQUIRED evidence step below
-# references only dense fields (RequestCount / TargetResponseTime), and every sparse
-# family gets its OWN on-failure:continue step. A failed/empty sparse step means "no
-# such errors ever observed on this LB" — that is itself a finding, never a failure.
 steps:
   # 0. Resolve the target + timestamp: manual inputs win; otherwise the triggering
   #    alert's structured group-by fields (kibana.alert.grouping.*) name the resource

--- a/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
+++ b/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
@@ -4,29 +4,33 @@ template-metadata:
   availability: ">=9.5.0"
   name: "AWS ALB 5xx surge investigation (OTel)"
   description: >-
-    Investigate an Application Load Balancer returning elevated 5xx. Distinguishes
-    backend target failures, LB-generated 5xx from no healthy targets, and latency
-    degradation using target health and response time. Requires AWS OTel metrics
-    from the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
+    Investigate an Application Load Balancer returning elevated 5xx. Layered
+    diagnosis: where the 5xx is generated (target vs per-code ELB 500/502/503/504),
+    why the ALB can't reach targets (connection/TLS errors, host health), whether
+    the ALB itself is under pressure (rejected connections), and backend latency.
+    Requires AWS OTel metrics from the EDOT awscloudwatch collector
+    (metrics-aws.*.otel-*).
   solutions: [observability]
   categories: [root-cause-analysis, monitoring]
 
 name: AWS ALB 5xx Surge Investigation (OTel)
 description: >
-  Automated investigation of an Application Load Balancer returning elevated 5xx.
-  An operator is paged on edge errors; this workflow decides whether the cause is the
-  TARGETS failing (backend 5xx / unhealthy hosts — e.g. the app can't reach its database)
-  versus the LOAD BALANCER itself having no healthy targets, versus latency degradation,
-  and correlates with target health + response time. Built against OTel-schema AWS
+  Automated layered investigation of an Application Load Balancer returning elevated
+  5xx. Layer 1 — where is the 5xx generated (target-generated vs ELB-generated, split
+  by code: 500 internal, 502 bad gateway, 503 no capacity/target, 504 timeout).
+  Layer 2 — why can't the ALB reach targets (TargetConnectionErrorCount,
+  TargetTLSNegotiationErrorCount, healthy/unhealthy host counts). Layer 3 — is the
+  ALB itself under pressure (RejectedConnectionCount vs request volume). Layer 4 —
+  application evidence (logs, when collected). Built against OTel-schema AWS
   CloudWatch metrics from the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
 
 consts:
   # `elb` is the canonical dataset of the aws_elb_metrics_otel package: its alert
   # templates and dashboard all read metrics-aws.elb.otel-* (NOT "applicationelb").
   alb_metrics_index: "metrics-aws.elb.otel-*"
+  logs_index: "logs-*.otel-*"
   # Baseline T-50m..T-20m vs incident T-20m..T+5m — windows must NOT overlap or
-  # incident data contaminates the baseline comparison. Recent pre-incident baseline
-  # (no deep history needed); widen for stable production LBs.
+  # incident data contaminates the baseline comparison.
   baseline_lookback: "50 minutes"
   baseline_lookend: "20 minutes"
   incident_lookback: "20 minutes"
@@ -59,12 +63,18 @@ triggers:
   - type: manual
   - type: alert
 
+# SPARSE-METRIC DISCIPLINE (learned on a live alert-triggered run): CloudWatch omits
+# zero-valued counters entirely, so a per-code or error-count field is UNMAPPED in
+# Elastic until the first such error ever occurs — and ES|QL fails verification on any
+# unknown column, killing the whole query. Therefore: the REQUIRED evidence step below
+# references only dense fields (RequestCount / TargetResponseTime), and every sparse
+# family gets its OWN on-failure:continue step. A failed/empty sparse step means "no
+# such errors ever observed on this LB" — that is itself a finding, never a failure.
 steps:
   # 0. Resolve the target + timestamp: manual inputs win; otherwise the triggering
   #    alert's structured group-by fields (kibana.alert.grouping.*) name the resource
-  #    and kibana.alert.start is the firing time. The LoadBalancer dimension arrives
-  #    intact as the full "app/<name>/<id>" reference. "MISSING" makes the incident
-  #    query match nothing so the evidence gate aborts cleanly.
+  #    and kibana.alert.start is the firing time. "MISSING" makes the incident query
+  #    match nothing so the evidence gate aborts cleanly.
   - name: resolve
     type: data.set
     with:
@@ -73,12 +83,7 @@ steps:
       service_name: "{{ inputs.service_name | default: 'the backend service' }}"
       triggering_rule: "{{ event.rule.name | default: 'manual run' }}"
 
-  # 1. Traffic volume + latency during the incident — the REQUIRED evidence base. This
-  #    step references ONLY dense metrics (RequestCount / TargetResponseTime exist whenever
-  #    the LB serves traffic). The 5xx counters are SPARSE CloudWatch metrics: the field is
-  #    unmapped until the first 5xx ever lands, and ES|QL fails verification on an unknown
-  #    column — a hard-failing query must never reference a field that may not exist yet,
-  #    so each sparse family gets its own optional step below.
+  # ── Layer 0: traffic context (REQUIRED — dense fields only; hard-fails) ──────────
   - name: traffic_incident
     type: elasticsearch.esql.query
     with:
@@ -92,7 +97,6 @@ steps:
             max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`) WHERE attributes.stat == "Maximum"
       format: json
 
-  # 2. Baseline traffic BEFORE the incident.
   - name: traffic_baseline
     type: elasticsearch.esql.query
     with:
@@ -101,12 +105,13 @@ steps:
         | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
           AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
           AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookend }}
-        | STATS baseline_requests = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`) WHERE attributes.stat == "Sum"
+        | STATS
+            baseline_requests   = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`)       WHERE attributes.stat == "Sum",
+            baseline_max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`) WHERE attributes.stat == "Maximum"
       format: json
 
-  # 3. Target 5xx, baseline vs incident in one phase-split query. OPTIONAL: the field may
-  #    be unmapped if the LB has never returned a target 5xx — its absence IS a finding
-  #    (no backend errors at all), never a reason to kill the run.
+  # ── Layer 1: WHERE is the 5xx generated? (each family sparse → optional) ─────────
+  # Target-generated 5xx: the application/backend answered with an error.
   - name: target_5xx
     type: elasticsearch.esql.query
     with:
@@ -122,25 +127,98 @@ steps:
     on-failure:
       continue: true
 
-  # 4. ELB-generated 5xx (LB has no healthy target to route to), same phase split.
-  #    OPTIONAL for the same sparse-field reason.
-  - name: elb_5xx
+  # ELB-generated 5xx, split by code. Each code is its own sparse field:
+  #   500 = ALB internal error; 502 = bad gateway (target reset / broke the HTTP
+  #   contract mid-request); 503 = no healthy target to route to / capacity;
+  #   504 = target exceeded the ALB timeout. The split localizes the mechanism.
+  - name: elb_500
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.alb_metrics_index }}
         | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
           AND attributes.stat == "Sum"
-          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
           AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
-        | EVAL phase = CASE(@timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}, "incident", "baseline")
-        | STATS elb_5xx = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count`) BY phase
+        | STATS elb_500 = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_500_Count`)
       format: json
     on-failure:
       continue: true
 
-  # 5. Target health — are backend hosts failing health checks? OPTIONAL corroboration
-  #    (host-count metrics may not be collected in every onboarding).
+  - name: elb_502
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | STATS elb_502 = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_502_Count`)
+      format: json
+    on-failure:
+      continue: true
+
+  - name: elb_503
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | STATS elb_503 = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_503_Count`)
+      format: json
+    on-failure:
+      continue: true
+
+  - name: elb_504
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | STATS elb_504 = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_504_Count`)
+      format: json
+    on-failure:
+      continue: true
+
+  # ── Layer 2: WHY can't the ALB reach targets? (sparse → optional) ────────────────
+  - name: target_conn_errors
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | STATS target_conn_errors = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/TargetConnectionErrorCount`)
+      format: json
+    on-failure:
+      continue: true
+
+  - name: target_tls_errors
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | STATS target_tls_errors = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/TargetTLSNegotiationErrorCount`)
+      format: json
+    on-failure:
+      continue: true
+
+  # Host health. No stat filter: HealthyHostCount/UnHealthyHostCount are one-sample-
+  # per-period gauges, so Average == Sum == Maximum per period and MIN/MAX are safe
+  # across both discovery-mode (per-stat gauges) and named-mode (reshaped) pipelines.
   - name: target_health
     type: elasticsearch.esql.query
     with:
@@ -150,20 +228,50 @@ steps:
           AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
           AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            min_healthy   = MIN(`metrics.amazonaws.com/AWS/ApplicationELB/HealthyHostCount`)   WHERE attributes.stat == "Average",
-            max_unhealthy = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount`) WHERE attributes.stat == "Average"
+            min_healthy   = MIN(`metrics.amazonaws.com/AWS/ApplicationELB/HealthyHostCount`),
+            max_unhealthy = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount`)
       format: json
     on-failure:
       continue: true
 
-  # 4. Evidence gate — deterministic, BEFORE any AI step. Zero datapoints for the
-  #    resolved load balancer (wrong/missing dimension, data not yet ingested,
-  #    degenerate alert group) → refuse to diagnose instead of classifying nulls.
+  # ── Layer 3: is the ALB ITSELF under pressure? (sparse → optional) ───────────────
+  - name: alb_pressure
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | STATS rejected_connections = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RejectedConnectionCount`)
+      format: json
+    on-failure:
+      continue: true
+
+  # ── Layer 4: application evidence (optional — logs may not be onboarded) ─────────
+  - name: app_logs
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.logs_index }}
+        | WHERE service.name == "{{ steps.resolve.output.service_name }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+          AND severity_text IN ("ERROR", "FATAL", "error", "fatal")
+        | SORT @timestamp DESC
+        | KEEP @timestamp, severity_text, body.text
+        | LIMIT 20
+      format: json
+    on-failure:
+      continue: true
+
+  # ── Evidence gate — deterministic, BEFORE any AI step ────────────────────────────
   - name: evidence_gate
     type: if
     condition: "steps.traffic_incident.output.documents_found > 0"
     steps:
-      # 5. Classify the failure locus.
+      # Classify the failure locus + mechanism.
       - name: classify_alb_failure
         type: ai.classify
         with:
@@ -172,28 +280,57 @@ steps:
             Traffic (incident): {{ steps.traffic_incident.output | json }}
             Traffic (baseline): {{ steps.traffic_baseline.output | json }}
             Target 5xx by phase: {{ steps.target_5xx.output | json }}
-            ELB 5xx by phase:    {{ steps.elb_5xx.output | json }}
-            Target health:       {{ steps.target_health.output | json }}
+            ELB 500 (incident): {{ steps.elb_500.output | json }}
+            ELB 502 (incident): {{ steps.elb_502.output | json }}
+            ELB 503 (incident): {{ steps.elb_503.output | json }}
+            ELB 504 (incident): {{ steps.elb_504.output | json }}
+            Target connection errors: {{ steps.target_conn_errors.output | json }}
+            Target TLS errors:        {{ steps.target_tls_errors.output | json }}
+            Target health:            {{ steps.target_health.output | json }}
+            ALB rejected connections: {{ steps.alb_pressure.output | json }}
+            App logs (errors):        {{ steps.app_logs.output | json }}
           categories:
-            - target_5xx_backend
-            - elb_5xx_no_healthy_targets
-            - latency_degradation
+            - target_application_5xx
+            - target_connection_failure
+            - target_tls_failure
+            - no_healthy_targets
+            - alb_capacity_pressure
+            - alb_internal_5xx
+            - backend_latency_timeout
             - healthy
+            - unrecognized
           instructions: |
-            Decide where the ALB failure originates:
-              - target_5xx_backend: target_5xx is elevated vs baseline (the registered targets
-                are returning 5xx — the application/backend is failing, e.g. it can't reach its
-                database). max_unhealthy may also be > 0.
-              - elb_5xx_no_healthy_targets: elb_5xx dominates and min_healthy is ~0 — the load
-                balancer itself returns 5xx because there are no healthy targets to route to.
-              - latency_degradation: 5xx is low but max_target_response is sharply elevated —
-                timeouts/slowness rather than hard errors.
-              - healthy: target_5xx/elb_5xx near baseline and hosts healthy.
-            Pick the single best category. Prefer target_5xx_backend when target 5xx is the
-            dominant elevated signal. A FAILED/empty 5xx step means that metric family has
-            never been emitted by this LB (CloudWatch omits zero-valued sparse metrics) —
-            treat it as "no such errors observed", and weigh the families that ARE present.
-            If the baseline returned no rows or nulls, note the comparison is unavailable.
+            Layered diagnosis — first decide WHERE the 5xx is generated, then the mechanism:
+              - target_application_5xx: target_5xx dominates (incident >> baseline) — the
+                registered targets themselves answered 5xx; the application/backend is
+                failing (check app logs for the specific error if present).
+              - target_connection_failure: target_conn_errors > 0 and/or elb_502 elevated —
+                the ALB could not establish/keep connections to targets (target resetting,
+                crashing mid-request, or port not accepting).
+              - target_tls_failure: target_tls_errors > 0 — backend TLS handshake failures
+                (cert expiry/mismatch on the target side).
+              - no_healthy_targets: elb_503 dominates and min_healthy is ~0 (or max_unhealthy
+                is the whole target group) — the ALB has nowhere to route.
+              - alb_capacity_pressure: rejected_connections > 0 — the ALB itself is refusing
+                connections (surge queue / connection limits), independent of target health.
+              - alb_internal_5xx: elb_500 elevated with none of the above — an ALB-internal
+                error (rare; often a config/rule evaluation problem).
+              - backend_latency_timeout: elb_504 elevated and/or max_target_response sharply
+                above baseline_max_target_response — targets respond but exceed the ALB
+                timeout; slowness, not hard failure.
+              - healthy: all 5xx families near zero/baseline, hosts healthy, latency stable.
+              - unrecognized: evidence conflicts or fits none of the above.
+            ABSENCE SEMANTICS: a FAILED or empty sparse step means that metric family has
+            NEVER been emitted by this LB (CloudWatch omits zero-valued counters) — read it
+            as "no such errors observed", never as missing data, and never fabricate a value.
+            COARSENING RULE: when the metric that separates two sibling categories is absent
+            (e.g. target_conn_errors vs target_tls_errors both never emitted, but elb_502 is
+            elevated), choose the COARSER truthful category (target_connection_failure for
+            502-dominance) and state in the rationale which discriminating metric was
+            unavailable. Do not fabricate precision the evidence cannot support.
+            MATERIALITY: compare against baseline where provided; small drifts within normal
+            fluctuation are ambient, not incidents. If baseline steps returned no rows, note
+            the comparison is unavailable — a missing baseline is not a zero baseline.
           includeRationale: true
 
       # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
@@ -238,34 +375,38 @@ steps:
             Traffic (incident): {{ steps.traffic_incident.output | json }}
             Traffic (baseline): {{ steps.traffic_baseline.output | json }}
             Target 5xx by phase: {{ steps.target_5xx.output | json }}
-            ELB 5xx by phase:    {{ steps.elb_5xx.output | json }}
-            Target health:       {{ steps.target_health.output | json }}
+            ELB 5xx by code: 500={{ steps.elb_500.output | json }} 502={{ steps.elb_502.output | json }} 503={{ steps.elb_503.output | json }} 504={{ steps.elb_504.output | json }}
+            Target reach: conn_errors={{ steps.target_conn_errors.output | json }} tls_errors={{ steps.target_tls_errors.output | json }}
+            Target health: {{ steps.target_health.output | json }}
+            ALB pressure:  {{ steps.alb_pressure.output | json }}
+            App logs:      {{ steps.app_logs.output | json }}
             SLO status:    {{ steps.slo_context.output | json }}
             Active alerts: {{ steps.active_alerts.output | json }}
           instructions: |
             You are an SRE assistant synthesising an AWS ALB incident investigation.
             Produce a structured root-cause summary in EXACTLY these sections:
-            ROOT CAUSE HYPOTHESIS — one sentence. If the targets are returning 5xx, name the
-              BACKEND ({{ steps.resolve.output.service_name }}) as the cause and note the next
-              place to look is that service's own dependencies (e.g. its database connection pool).
-            EVIDENCE — target vs ELB 5xx (incident vs baseline), target response time, healthy
-              vs unhealthy host counts.
-            SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
-              materially consumed), or an alert is active for this resource, ANCHOR severity
-              and root cause on that calibrated signal and name the alert/SLO + its reason
-              (the shipped thresholds encode what is "bad" for this resource, which the raw
-              magnitude alone cannot establish). If no SLO/alert context is present or empty,
-              state the assessment rests on raw metrics alone with no SLO/alert corroboration
-              — do NOT invent one.
-            CAUSAL CHAIN — backend dependency fails → {{ steps.resolve.output.service_name }}
-              returns 5xx → ALB target 5xx at the edge (adjust to the evidence; for
-              elb_5xx_no_healthy_targets, the chain is targets-unhealthy → LB has nowhere to
-              route → ELB 5xx).
-            RECOMMENDED NEXT STEPS — e.g. investigate {{ steps.resolve.output.service_name }}
-              and its backend (DB connection exhaustion?), check target health-check failures,
-              consider scaling or restarting unhealthy targets.
-            DOWNSTREAM IMPACT — user-facing symptom (failed requests / latency).
-            CONFIDENCE NOTE — only if ambiguous.
+            ROOT CAUSE HYPOTHESIS — one sentence naming the layer (target application /
+              target reachability / ALB capacity / ALB internal / backend latency) and the
+              mechanism. If the targets are answering 5xx, name the BACKEND
+              ({{ steps.resolve.output.service_name }}) and note the next place to look is
+              that service's own dependencies.
+            EVIDENCE — the per-code 5xx split, target vs ELB attribution, reach/health
+              signals, and latency vs baseline. Name what was ABSENT too (e.g. "no
+              connection or TLS errors ever recorded") — absence localizes the fault.
+            SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING or an alert is active
+              for this resource, ANCHOR severity on that calibrated signal and name it. If
+              no SLO/alert context is present, state the assessment rests on raw metrics
+              alone — do NOT invent one.
+            CAUSAL CHAIN — from the originating layer to the user-visible 5xx (adjust to
+              the classified mechanism).
+            RECOMMENDED NEXT STEPS — targeted at the classified layer (e.g. app logs/
+              dependencies for target_application_5xx; target process/port health for
+              connection failures; cert chain for TLS; scaling/health-check config for
+              no_healthy_targets; ALB limits for capacity; timeout tuning + profiling for
+              latency).
+            DOWNSTREAM IMPACT — user-facing symptom.
+            CONFIDENCE NOTE — required when a COARSENING rule was applied or a
+              discriminating metric family was absent.
           maxLength: 1500
 
       # Expose the result as the workflow's output for callers / composing workflows.

--- a/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
+++ b/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
@@ -21,177 +21,275 @@ description: >
   CloudWatch metrics from the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
 
 consts:
-  alb_metrics_index: "metrics-aws.applicationelb.otel-*"
-  # Recent pre-incident baseline (no deep history needed); widen for stable production LBs.
-  baseline_lookback: "45 minutes"
-  baseline_lookend: "12 minutes"
+  # `elb` is the canonical dataset of the aws_elb_metrics_otel package: its alert
+  # templates and dashboard all read metrics-aws.elb.otel-* (NOT "applicationelb").
+  alb_metrics_index: "metrics-aws.elb.otel-*"
+  # Baseline T-50m..T-20m vs incident T-20m..T+5m — windows must NOT overlap or
+  # incident data contaminates the baseline comparison. Recent pre-incident baseline
+  # (no deep history needed); widen for stable production LBs.
+  baseline_lookback: "50 minutes"
+  baseline_lookend: "20 minutes"
   incident_lookback: "20 minutes"
 
+# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
+# from the alert payload in the `resolve` step below.
+inputs:
+  - name: load_balancer
+    type: string
+    description: >-
+      ApplicationELB dimension of the alerting ALB (e.g. app/fis-demo-fleet-alb/<id>).
+      Manual runs must supply it; alert-triggered runs derive it from the alert.
+    required: false
+  - name: service_name
+    type: string
+    description: >-
+      The service behind the ALB target group (e.g. gateway).
+    required: false
+  - name: alert_timestamp
+    type: string
+    description: >-
+      ISO8601 timestamp of the alert firing. Manual runs must supply it;
+      alert-triggered runs derive it from the alert.
+    required: false
+
+# The alert trigger fires only when a rule is connected to this workflow via the
+# "Run Workflow" rule action (.workflows system connector). Configure that action
+# with summaryMode:false so each run carries exactly ONE alert in event.alerts.
 triggers:
-  - type: alert
   - type: manual
-    inputs:
-      - name: load_balancer
-        type: string
-        description: >-
-          ApplicationELB dimension of the alerting ALB
-          (e.g. app/fis-demo-fleet-alb/<id>).
-        required: true
-      - name: service_name
-        type: string
-        description: >-
-          The service behind the ALB target group (e.g. gateway).
-        required: true
-      - name: alert_timestamp
-        type: string
-        description: ISO8601 timestamp of the alert firing.
-        required: true
+  - type: alert
 
 steps:
-  # 1. Error volume + latency during the incident. Target 5xx points at the backend;
-  #    ELB 5xx (LB-generated) points at no-healthy-targets / connection rejection.
-  - name: errors_incident
+  # 0. Resolve the target + timestamp: manual inputs win; otherwise the triggering
+  #    alert's structured group-by fields (kibana.alert.grouping.*) name the resource
+  #    and kibana.alert.start is the firing time. The LoadBalancer dimension arrives
+  #    intact as the full "app/<name>/<id>" reference. "MISSING" makes the incident
+  #    query match nothing so the evidence gate aborts cleanly.
+  - name: resolve
+    type: data.set
+    with:
+      load_balancer: "{{ inputs.load_balancer | default: event.alerts[0].kibana.alert.grouping.LoadBalancer | default: 'MISSING' }}"
+      alert_timestamp: "{{ inputs.alert_timestamp | default: event.alerts[0].kibana.alert.start | default: 'MISSING' }}"
+      service_name: "{{ inputs.service_name | default: 'the backend service' }}"
+      triggering_rule: "{{ event.rule.name | default: 'manual run' }}"
+
+  # 1. Traffic volume + latency during the incident — the REQUIRED evidence base. This
+  #    step references ONLY dense metrics (RequestCount / TargetResponseTime exist whenever
+  #    the LB serves traffic). The 5xx counters are SPARSE CloudWatch metrics: the field is
+  #    unmapped until the first 5xx ever lands, and ES|QL fails verification on an unknown
+  #    column — a hard-failing query must never reference a field that may not exist yet,
+  #    so each sparse family gets its own optional step below.
+  - name: traffic_incident
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.alb_metrics_index }}
-        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            target_5xx          = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count`),
-            elb_5xx             = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count`),
-            request_count       = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`),
-            max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`)
+            request_count       = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`)       WHERE attributes.stat == "Sum",
+            max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`) WHERE attributes.stat == "Maximum"
       format: json
-    on-failure:
-      continue: true
 
-  # 2. Baseline error volume BEFORE the incident.
-  - name: errors_baseline
+  # 2. Baseline traffic BEFORE the incident.
+  - name: traffic_baseline
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.alb_metrics_index }}
-        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
-        | STATS
-            baseline_target_5xx = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count`),
-            baseline_requests   = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`)
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | STATS baseline_requests = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`) WHERE attributes.stat == "Sum"
+      format: json
+
+  # 3. Target 5xx, baseline vs incident in one phase-split query. OPTIONAL: the field may
+  #    be unmapped if the LB has never returned a target 5xx — its absence IS a finding
+  #    (no backend errors at all), never a reason to kill the run.
+  - name: target_5xx
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | EVAL phase = CASE(@timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}, "incident", "baseline")
+        | STATS target_5xx = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count`) BY phase
       format: json
     on-failure:
       continue: true
 
-  # 3. Target health — are backend hosts failing health checks (the backend is down /
-  #    can't serve)? Unhealthy hosts alongside target 5xx => the targets are the cause.
+  # 4. ELB-generated 5xx (LB has no healthy target to route to), same phase split.
+  #    OPTIONAL for the same sparse-field reason.
+  - name: elb_5xx
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND attributes.stat == "Sum"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+        | EVAL phase = CASE(@timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}, "incident", "baseline")
+        | STATS elb_5xx = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count`) BY phase
+      format: json
+    on-failure:
+      continue: true
+
+  # 5. Target health — are backend hosts failing health checks? OPTIONAL corroboration
+  #    (host-count metrics may not be collected in every onboarding).
   - name: target_health
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.alb_metrics_index }}
-        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            min_healthy   = MIN(`metrics.amazonaws.com/AWS/ApplicationELB/HealthyHostCount`),
-            max_unhealthy = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount`)
+            min_healthy   = MIN(`metrics.amazonaws.com/AWS/ApplicationELB/HealthyHostCount`)   WHERE attributes.stat == "Average",
+            max_unhealthy = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount`) WHERE attributes.stat == "Average"
       format: json
     on-failure:
       continue: true
 
-  # 4. Classify the failure locus.
-  - name: classify_alb_failure
-    type: ai.classify
-    with:
-      input: |
-        LoadBalancer: {{ inputs.load_balancer }}
-        Errors (incident): {{ steps.errors_incident.output | json }}
-        Errors (baseline): {{ steps.errors_baseline.output | json }}
-        Target health:     {{ steps.target_health.output | json }}
-      categories:
-        - target_5xx_backend
-        - elb_5xx_no_healthy_targets
-        - latency_degradation
-        - healthy
-      instructions: |
-        Decide where the ALB failure originates:
-          - target_5xx_backend: target_5xx is elevated vs baseline (the registered targets
-            are returning 5xx — the application/backend is failing, e.g. it can't reach its
-            database). max_unhealthy may also be > 0.
-          - elb_5xx_no_healthy_targets: elb_5xx dominates and min_healthy is ~0 — the load
-            balancer itself returns 5xx because there are no healthy targets to route to.
-          - latency_degradation: 5xx is low but max_target_response is sharply elevated —
-            timeouts/slowness rather than hard errors.
-          - healthy: target_5xx/elb_5xx near baseline and hosts healthy.
-        Pick the single best category. Prefer target_5xx_backend when target 5xx is the
-        dominant elevated signal.
-      includeRationale: true
+  # 4. Evidence gate — deterministic, BEFORE any AI step. Zero datapoints for the
+  #    resolved load balancer (wrong/missing dimension, data not yet ingested,
+  #    degenerate alert group) → refuse to diagnose instead of classifying nulls.
+  - name: evidence_gate
+    type: if
+    condition: "steps.traffic_incident.output.documents_found > 0"
+    steps:
+      # 5. Classify the failure locus.
+      - name: classify_alb_failure
+        type: ai.classify
+        with:
+          input: |
+            LoadBalancer: {{ steps.resolve.output.load_balancer }}
+            Traffic (incident): {{ steps.traffic_incident.output | json }}
+            Traffic (baseline): {{ steps.traffic_baseline.output | json }}
+            Target 5xx by phase: {{ steps.target_5xx.output | json }}
+            ELB 5xx by phase:    {{ steps.elb_5xx.output | json }}
+            Target health:       {{ steps.target_health.output | json }}
+          categories:
+            - target_5xx_backend
+            - elb_5xx_no_healthy_targets
+            - latency_degradation
+            - healthy
+          instructions: |
+            Decide where the ALB failure originates:
+              - target_5xx_backend: target_5xx is elevated vs baseline (the registered targets
+                are returning 5xx — the application/backend is failing, e.g. it can't reach its
+                database). max_unhealthy may also be > 0.
+              - elb_5xx_no_healthy_targets: elb_5xx dominates and min_healthy is ~0 — the load
+                balancer itself returns 5xx because there are no healthy targets to route to.
+              - latency_degradation: 5xx is low but max_target_response is sharply elevated —
+                timeouts/slowness rather than hard errors.
+              - healthy: target_5xx/elb_5xx near baseline and hosts healthy.
+            Pick the single best category. Prefer target_5xx_backend when target 5xx is the
+            dominant elevated signal. A FAILED/empty 5xx step means that metric family has
+            never been emitted by this LB (CloudWatch omits zero-valued sparse metrics) —
+            treat it as "no such errors observed", and weigh the families that ARE present.
+            If the baseline returned no rows or nulls, note the comparison is unavailable.
+          includeRationale: true
 
-  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
-  - name: slo_context
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .slo-observability.summary-*
-        | WHERE slo.instanceId LIKE "*{{ inputs.load_balancer }}*"
-        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
-      format: json
-    on-failure:
-      continue: true
+      # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+      - name: slo_context
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .slo-observability.summary-*
+            | WHERE slo.instanceId LIKE "*{{ steps.resolve.output.load_balancer }}*"
+            | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+          format: json
+        on-failure:
+          continue: true
 
-  - name: active_alerts
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .alerts-*
-        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.load_balancer }}*"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
-        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
-        | SORT kibana.alert.start DESC
-        | LIMIT 20
-      format: json
-    on-failure:
-      continue: true
+      - name: active_alerts
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .alerts-*
+            | WHERE kibana.alert.instance.id LIKE "*{{ steps.resolve.output.load_balancer }}*"
+              AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+              AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+            | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+            | SORT kibana.alert.start DESC
+            | LIMIT 20
+          format: json
+        on-failure:
+          continue: true
 
-  - name: synthesize_findings
-    type: ai.summarize
-    with:
-      input: |
-        ## ALB 5xx investigation for {{ inputs.load_balancer }}
-        Alert timestamp: {{ inputs.alert_timestamp }}
-        Backing service: {{ inputs.service_name }}
+      - name: synthesize_findings
+        type: ai.summarize
+        with:
+          input: |
+            ## ALB 5xx investigation for {{ steps.resolve.output.load_balancer }}
+            Alert timestamp: {{ steps.resolve.output.alert_timestamp }}
+            Triggered by: {{ steps.resolve.output.triggering_rule }}
+            Backing service: {{ steps.resolve.output.service_name }}
 
-        Classification: {{ steps.classify_alb_failure.output.category }}
-        Rationale: {{ steps.classify_alb_failure.output.rationale }}
+            Classification: {{ steps.classify_alb_failure.output.category }}
+            Rationale: {{ steps.classify_alb_failure.output.rationale }}
 
-        Errors (incident): {{ steps.errors_incident.output | json }}
-        Errors (baseline): {{ steps.errors_baseline.output | json }}
-        Target health:     {{ steps.target_health.output | json }}
-        SLO status:    {{ steps.slo_context.output | json }}
-        Active alerts: {{ steps.active_alerts.output | json }}
-      instructions: |
-        You are an SRE assistant synthesising an AWS ALB incident investigation.
-        Produce a structured root-cause summary in EXACTLY these sections:
-        ROOT CAUSE HYPOTHESIS — one sentence. If the targets are returning 5xx, name the
-          BACKEND ({{ inputs.service_name }}) as the cause and note the next place to look
-          is that service's own dependencies (e.g. its database connection pool).
-        EVIDENCE — target vs ELB 5xx (incident vs baseline), target response time, healthy
-          vs unhealthy host counts.
-        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
-          materially consumed), or an alert is active for this resource, ANCHOR severity
-          and root cause on that calibrated signal and name the alert/SLO + its reason
-          (the shipped thresholds encode what is "bad" for this resource, which the raw
-          magnitude alone cannot establish). If no SLO/alert context is present or empty,
-          state the assessment rests on raw metrics alone with no SLO/alert corroboration
-          — do NOT invent one.
-        CAUSAL CHAIN — backend dependency fails → {{ inputs.service_name }} returns 5xx →
-          ALB target 5xx at the edge (adjust to the evidence; for elb_5xx_no_healthy_targets,
-          the chain is targets-unhealthy → LB has nowhere to route → ELB 5xx).
-        RECOMMENDED NEXT STEPS — e.g. investigate {{ inputs.service_name }} and its backend
-          (DB connection exhaustion?), check target health-check failures, consider scaling
-          or restarting unhealthy targets.
-        DOWNSTREAM IMPACT — user-facing symptom (failed requests / latency).
-        CONFIDENCE NOTE — only if ambiguous.
-      maxLength: 1500
+            Traffic (incident): {{ steps.traffic_incident.output | json }}
+            Traffic (baseline): {{ steps.traffic_baseline.output | json }}
+            Target 5xx by phase: {{ steps.target_5xx.output | json }}
+            ELB 5xx by phase:    {{ steps.elb_5xx.output | json }}
+            Target health:       {{ steps.target_health.output | json }}
+            SLO status:    {{ steps.slo_context.output | json }}
+            Active alerts: {{ steps.active_alerts.output | json }}
+          instructions: |
+            You are an SRE assistant synthesising an AWS ALB incident investigation.
+            Produce a structured root-cause summary in EXACTLY these sections:
+            ROOT CAUSE HYPOTHESIS — one sentence. If the targets are returning 5xx, name the
+              BACKEND ({{ steps.resolve.output.service_name }}) as the cause and note the next
+              place to look is that service's own dependencies (e.g. its database connection pool).
+            EVIDENCE — target vs ELB 5xx (incident vs baseline), target response time, healthy
+              vs unhealthy host counts.
+            SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+              materially consumed), or an alert is active for this resource, ANCHOR severity
+              and root cause on that calibrated signal and name the alert/SLO + its reason
+              (the shipped thresholds encode what is "bad" for this resource, which the raw
+              magnitude alone cannot establish). If no SLO/alert context is present or empty,
+              state the assessment rests on raw metrics alone with no SLO/alert corroboration
+              — do NOT invent one.
+            CAUSAL CHAIN — backend dependency fails → {{ steps.resolve.output.service_name }}
+              returns 5xx → ALB target 5xx at the edge (adjust to the evidence; for
+              elb_5xx_no_healthy_targets, the chain is targets-unhealthy → LB has nowhere to
+              route → ELB 5xx).
+            RECOMMENDED NEXT STEPS — e.g. investigate {{ steps.resolve.output.service_name }}
+              and its backend (DB connection exhaustion?), check target health-check failures,
+              consider scaling or restarting unhealthy targets.
+            DOWNSTREAM IMPACT — user-facing symptom (failed requests / latency).
+            CONFIDENCE NOTE — only if ambiguous.
+          maxLength: 1500
+
+      # Expose the result as the workflow's output for callers / composing workflows.
+      - name: output_result
+        type: workflow.output
+        with:
+          status: "investigated"
+          resource: "{{ steps.resolve.output.load_balancer }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          classification: "{{ steps.classify_alb_failure.output.category }}"
+          rationale: "{{ steps.classify_alb_failure.output.rationale }}"
+          summary: "{{ steps.synthesize_findings.output.content }}"
+
+    else:
+      - name: output_insufficient_evidence
+        type: workflow.output
+        with:
+          status: "insufficient_evidence"
+          resource: "{{ steps.resolve.output.load_balancer }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          summary: >-
+            No ALB datapoints found for "{{ steps.resolve.output.load_balancer }}" in the
+            incident window around {{ steps.resolve.output.alert_timestamp }}. Either the
+            LoadBalancer dimension could not be resolved (manual input missing, or the
+            triggering alert's group carries no LoadBalancer), the metrics have not been
+            ingested yet, or the dimension does not match this cluster's data. Refusing
+            to produce a diagnosis without evidence.

--- a/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
+++ b/library/workflows/aws-alb-5xx-investigation-otel/aws-alb-5xx-investigation-otel.yaml
@@ -1,0 +1,197 @@
+template-metadata:
+  slug: aws-alb-5xx-investigation-otel
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "AWS ALB 5xx surge investigation (OTel)"
+  description: >-
+    Investigate an Application Load Balancer returning elevated 5xx. Distinguishes
+    backend target failures, LB-generated 5xx from no healthy targets, and latency
+    degradation using target health and response time. Requires AWS OTel metrics
+    from the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
+  solutions: [observability]
+  categories: [root-cause-analysis, monitoring]
+
+name: AWS ALB 5xx Surge Investigation (OTel)
+description: >
+  Automated investigation of an Application Load Balancer returning elevated 5xx.
+  An operator is paged on edge errors; this workflow decides whether the cause is the
+  TARGETS failing (backend 5xx / unhealthy hosts — e.g. the app can't reach its database)
+  versus the LOAD BALANCER itself having no healthy targets, versus latency degradation,
+  and correlates with target health + response time. Built against OTel-schema AWS
+  CloudWatch metrics from the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
+
+consts:
+  alb_metrics_index: "metrics-aws.applicationelb.otel-*"
+  # Recent pre-incident baseline (no deep history needed); widen for stable production LBs.
+  baseline_lookback: "45 minutes"
+  baseline_lookend: "12 minutes"
+  incident_lookback: "20 minutes"
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: load_balancer
+        type: string
+        description: >-
+          ApplicationELB dimension of the alerting ALB
+          (e.g. app/fis-demo-fleet-alb/<id>).
+        required: true
+      - name: service_name
+        type: string
+        description: >-
+          The service behind the ALB target group (e.g. gateway).
+        required: true
+      - name: alert_timestamp
+        type: string
+        description: ISO8601 timestamp of the alert firing.
+        required: true
+
+steps:
+  # 1. Error volume + latency during the incident. Target 5xx points at the backend;
+  #    ELB 5xx (LB-generated) points at no-healthy-targets / connection rejection.
+  - name: errors_incident
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            target_5xx          = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count`),
+            elb_5xx             = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count`),
+            request_count       = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`),
+            max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 2. Baseline error volume BEFORE the incident.
+  - name: errors_baseline
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | STATS
+            baseline_target_5xx = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count`),
+            baseline_requests   = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 3. Target health — are backend hosts failing health checks (the backend is down /
+  #    can't serve)? Unhealthy hosts alongside target 5xx => the targets are the cause.
+  - name: target_health
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            min_healthy   = MIN(`metrics.amazonaws.com/AWS/ApplicationELB/HealthyHostCount`),
+            max_unhealthy = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 4. Classify the failure locus.
+  - name: classify_alb_failure
+    type: ai.classify
+    with:
+      input: |
+        LoadBalancer: {{ inputs.load_balancer }}
+        Errors (incident): {{ steps.errors_incident.output | json }}
+        Errors (baseline): {{ steps.errors_baseline.output | json }}
+        Target health:     {{ steps.target_health.output | json }}
+      categories:
+        - target_5xx_backend
+        - elb_5xx_no_healthy_targets
+        - latency_degradation
+        - healthy
+      instructions: |
+        Decide where the ALB failure originates:
+          - target_5xx_backend: target_5xx is elevated vs baseline (the registered targets
+            are returning 5xx — the application/backend is failing, e.g. it can't reach its
+            database). max_unhealthy may also be > 0.
+          - elb_5xx_no_healthy_targets: elb_5xx dominates and min_healthy is ~0 — the load
+            balancer itself returns 5xx because there are no healthy targets to route to.
+          - latency_degradation: 5xx is low but max_target_response is sharply elevated —
+            timeouts/slowness rather than hard errors.
+          - healthy: target_5xx/elb_5xx near baseline and hosts healthy.
+        Pick the single best category. Prefer target_5xx_backend when target 5xx is the
+        dominant elevated signal.
+      includeRationale: true
+
+  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+  - name: slo_context
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .slo-observability.summary-*
+        | WHERE slo.instanceId LIKE "*{{ inputs.load_balancer }}*"
+        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+      format: json
+    on-failure:
+      continue: true
+
+  - name: active_alerts
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .alerts-*
+        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.load_balancer }}*"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+        | SORT kibana.alert.start DESC
+        | LIMIT 20
+      format: json
+    on-failure:
+      continue: true
+
+  - name: synthesize_findings
+    type: ai.summarize
+    with:
+      input: |
+        ## ALB 5xx investigation for {{ inputs.load_balancer }}
+        Alert timestamp: {{ inputs.alert_timestamp }}
+        Backing service: {{ inputs.service_name }}
+
+        Classification: {{ steps.classify_alb_failure.output.category }}
+        Rationale: {{ steps.classify_alb_failure.output.rationale }}
+
+        Errors (incident): {{ steps.errors_incident.output | json }}
+        Errors (baseline): {{ steps.errors_baseline.output | json }}
+        Target health:     {{ steps.target_health.output | json }}
+        SLO status:    {{ steps.slo_context.output | json }}
+        Active alerts: {{ steps.active_alerts.output | json }}
+      instructions: |
+        You are an SRE assistant synthesising an AWS ALB incident investigation.
+        Produce a structured root-cause summary in EXACTLY these sections:
+        ROOT CAUSE HYPOTHESIS — one sentence. If the targets are returning 5xx, name the
+          BACKEND ({{ inputs.service_name }}) as the cause and note the next place to look
+          is that service's own dependencies (e.g. its database connection pool).
+        EVIDENCE — target vs ELB 5xx (incident vs baseline), target response time, healthy
+          vs unhealthy host counts.
+        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+          materially consumed), or an alert is active for this resource, ANCHOR severity
+          and root cause on that calibrated signal and name the alert/SLO + its reason
+          (the shipped thresholds encode what is "bad" for this resource, which the raw
+          magnitude alone cannot establish). If no SLO/alert context is present or empty,
+          state the assessment rests on raw metrics alone with no SLO/alert corroboration
+          — do NOT invent one.
+        CAUSAL CHAIN — backend dependency fails → {{ inputs.service_name }} returns 5xx →
+          ALB target 5xx at the edge (adjust to the evidence; for elb_5xx_no_healthy_targets,
+          the chain is targets-unhealthy → LB has nowhere to route → ELB 5xx).
+        RECOMMENDED NEXT STEPS — e.g. investigate {{ inputs.service_name }} and its backend
+          (DB connection exhaustion?), check target health-check failures, consider scaling
+          or restarting unhealthy targets.
+        DOWNSTREAM IMPACT — user-facing symptom (failed requests / latency).
+        CONFIDENCE NOTE — only if ambiguous.
+      maxLength: 1500

--- a/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
+++ b/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
@@ -22,45 +22,68 @@ description: >
 
 consts:
   lambda_metrics_index: "metrics-aws.lambda.otel-*"
-  baseline_lookback: "45 minutes"
-  baseline_lookend: "12 minutes"
+  # Baseline T-50m..T-20m vs incident T-20m..T+5m — windows must NOT overlap or
+  # incident data contaminates the baseline comparison.
+  baseline_lookback: "50 minutes"
+  baseline_lookend: "20 minutes"
   incident_lookback: "20 minutes"
 
+# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
+# from the alert payload in the `resolve` step below.
+inputs:
+  - name: function_name
+    type: string
+    description: >-
+      Lambda FunctionName of the alerting function (e.g. fis-worker-fns-0).
+      Manual runs must supply it; alert-triggered runs derive it from the alert.
+    required: false
+  - name: alert_timestamp
+    type: string
+    description: >-
+      ISO8601 timestamp of the alert firing. Manual runs must supply it;
+      alert-triggered runs derive it from the alert.
+    required: false
+
+# The alert trigger fires only when a rule is connected to this workflow via the
+# "Run Workflow" rule action (.workflows system connector). Configure that action
+# with summaryMode:false so each run carries exactly ONE alert in event.alerts.
 triggers:
-  - type: alert
   - type: manual
-    inputs:
-      - name: function_name
-        type: string
-        description: >-
-          Lambda FunctionName of the alerting function (e.g. fis-worker-fns-0).
-        required: true
-      - name: alert_timestamp
-        type: string
-        description: ISO8601 timestamp of the alert firing.
-        required: true
+  - type: alert
 
 steps:
+  # 0. Resolve the target + timestamp: manual inputs win; otherwise the triggering
+  #    alert's structured group-by fields (kibana.alert.grouping.*) name the resource
+  #    and kibana.alert.start is the firing time. "MISSING" makes the incident query
+  #    match nothing so the evidence gate aborts cleanly.
+  - name: resolve
+    type: data.set
+    with:
+      function_name: "{{ inputs.function_name | default: event.alerts[0].kibana.alert.grouping.FunctionName | default: 'MISSING' }}"
+      alert_timestamp: "{{ inputs.alert_timestamp | default: event.alerts[0].kibana.alert.start | default: 'MISSING' }}"
+      triggering_rule: "{{ event.rule.name | default: 'manual run' }}"
+
   # 1. Failure signals during the incident: errors, the error RATE (errors/invocations),
-  #    throttles, peak concurrency, and slowest duration.
+  #    throttles, peak concurrency, and slowest duration. REQUIRED evidence: a query
+  #    failure fails the run rather than feeding empty output into the classifier.
+  #    Zero invocations yields a null error_rate (not a fake 0%): CASE guards the
+  #    division so low-volume rates are exact (1 error / 1 invocation = 100%).
   - name: errors_incident
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.lambda_metrics_index }}
-        | WHERE attributes.FunctionName == "{{ inputs.function_name }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | WHERE attributes.FunctionName == "{{ steps.resolve.output.function_name }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            errors       = SUM(`metrics.amazonaws.com/AWS/Lambda/Errors`),
-            invocations  = SUM(`metrics.amazonaws.com/AWS/Lambda/Invocations`),
-            throttles    = SUM(`metrics.amazonaws.com/AWS/Lambda/Throttles`),
-            max_duration = MAX(`metrics.amazonaws.com/AWS/Lambda/Duration`),
-            max_concurrency = MAX(`metrics.amazonaws.com/AWS/Lambda/ConcurrentExecutions`)
-        | EVAL error_rate = TO_DOUBLE(errors) / TO_DOUBLE(invocations + 1)
+            errors       = SUM(`metrics.amazonaws.com/AWS/Lambda/Errors`)      WHERE attributes.stat == "Sum",
+            invocations  = SUM(`metrics.amazonaws.com/AWS/Lambda/Invocations`) WHERE attributes.stat == "Sum",
+            throttles    = SUM(`metrics.amazonaws.com/AWS/Lambda/Throttles`)   WHERE attributes.stat == "Sum",
+            max_duration = MAX(`metrics.amazonaws.com/AWS/Lambda/Duration`)    WHERE attributes.stat == "Maximum",
+            max_concurrency = MAX(`metrics.amazonaws.com/AWS/Lambda/ConcurrentExecutions`) WHERE attributes.stat == "Maximum"
+        | EVAL error_rate = CASE(invocations > 0, TO_DOUBLE(errors) / TO_DOUBLE(invocations), null)
       format: json
-    on-failure:
-      continue: true
 
   # 2. Baseline failure rate BEFORE the incident.
   - name: errors_baseline
@@ -68,102 +91,141 @@ steps:
     with:
       query: |
         FROM {{ consts.lambda_metrics_index }}
-        | WHERE attributes.FunctionName == "{{ inputs.function_name }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | WHERE attributes.FunctionName == "{{ steps.resolve.output.function_name }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookend }}
         | STATS
-            errors      = SUM(`metrics.amazonaws.com/AWS/Lambda/Errors`),
-            invocations = SUM(`metrics.amazonaws.com/AWS/Lambda/Invocations`),
-            max_duration = MAX(`metrics.amazonaws.com/AWS/Lambda/Duration`)
-        | EVAL baseline_error_rate = TO_DOUBLE(errors) / TO_DOUBLE(invocations + 1)
+            errors      = SUM(`metrics.amazonaws.com/AWS/Lambda/Errors`)      WHERE attributes.stat == "Sum",
+            invocations = SUM(`metrics.amazonaws.com/AWS/Lambda/Invocations`) WHERE attributes.stat == "Sum",
+            max_duration = MAX(`metrics.amazonaws.com/AWS/Lambda/Duration`)   WHERE attributes.stat == "Maximum"
+        | EVAL baseline_error_rate = CASE(invocations > 0, TO_DOUBLE(errors) / TO_DOUBLE(invocations), null)
       format: json
-    on-failure:
-      continue: true
 
-  # 3. Classify the Lambda failure mode.
-  - name: classify_lambda_pattern
-    type: ai.classify
-    with:
-      input: |
-        FunctionName: {{ inputs.function_name }}
-        Incident: {{ steps.errors_incident.output | json }}
-        Baseline: {{ steps.errors_baseline.output | json }}
-      categories:
-        - elevated_errors
-        - throttling
-        - duration_degradation
-        - healthy
-      instructions: |
-        Classify the dominant Lambda failure mode:
-          - throttling: throttles > 0 and/or max_concurrency pinned at a limit — invocations
-            are being rejected because concurrency is exhausted (scale / reserved-concurrency issue).
-          - elevated_errors: error_rate is well above baseline_error_rate with few/no throttles —
-            the function code/dependency is failing.
-          - duration_degradation: error_rate near baseline but max_duration sharply up — the
-            function is slow (downstream latency / cold starts / resource limits).
-          - healthy: error_rate near baseline, no throttles, duration stable.
-        Pick the single best category; prefer throttling when throttles > 0.
-      includeRationale: true
+  # 3. Evidence gate — deterministic, BEFORE any AI step. Zero datapoints for the
+  #    resolved function (wrong/missing name, data not yet ingested, degenerate alert
+  #    group) → refuse to diagnose instead of classifying a row of nulls.
+  - name: evidence_gate
+    type: if
+    condition: "steps.errors_incident.output.documents_found > 0"
+    steps:
+      # 4. Classify the Lambda failure mode.
+      - name: classify_lambda_pattern
+        type: ai.classify
+        with:
+          input: |
+            FunctionName: {{ steps.resolve.output.function_name }}
+            Incident: {{ steps.errors_incident.output | json }}
+            Baseline: {{ steps.errors_baseline.output | json }}
+          categories:
+            - elevated_errors
+            - throttling
+            - duration_degradation
+            - healthy
+          instructions: |
+            Classify the dominant Lambda failure mode:
+              - throttling: throttles > 0 and/or max_concurrency pinned at a limit — invocations
+                are being rejected because concurrency is exhausted (scale / reserved-concurrency issue).
+              - elevated_errors: error_rate is MATERIALLY above baseline_error_rate (roughly
+                2x or more, or a jump of many percentage points) with few/no throttles —
+                the function code/dependency is failing.
+              - duration_degradation: error_rate near baseline but max_duration sharply up — the
+                function is slow (downstream latency / cold starts / resource limits).
+              - healthy: error_rate within normal fluctuation of baseline (small drifts of a
+                couple of percentage points are ambient noise, NOT an incident), no throttles,
+                duration stable.
+            Pick the single best category; prefer throttling when throttles > 0.
+            A null error_rate means zero invocations in the window — do not read it as 0%;
+            if invocations are zero while throttles are high, that IS the throttling pattern.
+            If the baseline returned no rows or nulls, note the comparison is unavailable —
+            do not treat a missing baseline as a zero baseline.
+          includeRationale: true
 
-  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
-  - name: slo_context
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .slo-observability.summary-*
-        | WHERE slo.instanceId LIKE "*{{ inputs.function_name }}*"
-        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
-      format: json
-    on-failure:
-      continue: true
+      # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+      - name: slo_context
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .slo-observability.summary-*
+            | WHERE slo.instanceId LIKE "*{{ steps.resolve.output.function_name }}*"
+            | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+          format: json
+        on-failure:
+          continue: true
 
-  - name: active_alerts
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .alerts-*
-        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.function_name }}*"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
-        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
-        | SORT kibana.alert.start DESC
-        | LIMIT 20
-      format: json
-    on-failure:
-      continue: true
+      - name: active_alerts
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .alerts-*
+            | WHERE kibana.alert.instance.id LIKE "*{{ steps.resolve.output.function_name }}*"
+              AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+              AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+            | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+            | SORT kibana.alert.start DESC
+            | LIMIT 20
+          format: json
+        on-failure:
+          continue: true
 
-  - name: synthesize_findings
-    type: ai.summarize
-    with:
-      input: |
-        ## Lambda incident investigation for {{ inputs.function_name }}
-        Alert timestamp: {{ inputs.alert_timestamp }}
+      - name: synthesize_findings
+        type: ai.summarize
+        with:
+          input: |
+            ## Lambda incident investigation for {{ steps.resolve.output.function_name }}
+            Alert timestamp: {{ steps.resolve.output.alert_timestamp }}
+            Triggered by: {{ steps.resolve.output.triggering_rule }}
 
-        Classification: {{ steps.classify_lambda_pattern.output.category }}
-        Rationale: {{ steps.classify_lambda_pattern.output.rationale }}
+            Classification: {{ steps.classify_lambda_pattern.output.category }}
+            Rationale: {{ steps.classify_lambda_pattern.output.rationale }}
 
-        Incident: {{ steps.errors_incident.output | json }}
-        Baseline: {{ steps.errors_baseline.output | json }}
-        SLO status:    {{ steps.slo_context.output | json }}
-        Active alerts: {{ steps.active_alerts.output | json }}
-      instructions: |
-        You are an SRE assistant synthesising an AWS Lambda incident investigation.
-        Produce a structured root-cause summary in EXACTLY these sections:
-        ROOT CAUSE HYPOTHESIS — one sentence naming the dominant failure mode.
-        EVIDENCE — errors, invocations, error_rate vs baseline_error_rate, throttles,
-          max_concurrency, max_duration.
-        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
-          materially consumed), or an alert is active for this resource, ANCHOR severity
-          and root cause on that calibrated signal and name the alert/SLO + its reason
-          (the shipped thresholds encode what is "bad" for this resource, which the raw
-          magnitude alone cannot establish). If no SLO/alert context is present or empty,
-          state the assessment rests on raw metrics alone with no SLO/alert corroboration
-          — do NOT invent one.
-        CAUSAL CHAIN — adjust to the evidence (e.g. arrival spike → concurrency exhausted →
-          throttles → dropped/failed invocations; or a failing dependency → error rate up).
-        RECOMMENDED NEXT STEPS — e.g. raise reserved/provisioned concurrency for throttling;
-          inspect function logs / the failing dependency for elevated_errors; profile cold
-          starts / downstream calls for duration_degradation.
-        DOWNSTREAM IMPACT — what the failed/throttled invocations affect.
-        CONFIDENCE NOTE — only if ambiguous.
-      maxLength: 1500
+            Incident: {{ steps.errors_incident.output | json }}
+            Baseline: {{ steps.errors_baseline.output | json }}
+            SLO status:    {{ steps.slo_context.output | json }}
+            Active alerts: {{ steps.active_alerts.output | json }}
+          instructions: |
+            You are an SRE assistant synthesising an AWS Lambda incident investigation.
+            Produce a structured root-cause summary in EXACTLY these sections:
+            ROOT CAUSE HYPOTHESIS — one sentence naming the dominant failure mode.
+            EVIDENCE — errors, invocations, error_rate vs baseline_error_rate, throttles,
+              max_concurrency, max_duration.
+            SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+              materially consumed), or an alert is active for this resource, ANCHOR severity
+              and root cause on that calibrated signal and name the alert/SLO + its reason
+              (the shipped thresholds encode what is "bad" for this resource, which the raw
+              magnitude alone cannot establish). If no SLO/alert context is present or empty,
+              state the assessment rests on raw metrics alone with no SLO/alert corroboration
+              — do NOT invent one.
+            CAUSAL CHAIN — adjust to the evidence (e.g. arrival spike → concurrency exhausted →
+              throttles → dropped/failed invocations; or a failing dependency → error rate up).
+            RECOMMENDED NEXT STEPS — e.g. raise reserved/provisioned concurrency for throttling;
+              inspect function logs / the failing dependency for elevated_errors; profile cold
+              starts / downstream calls for duration_degradation.
+            DOWNSTREAM IMPACT — what the failed/throttled invocations affect.
+            CONFIDENCE NOTE — only if ambiguous.
+          maxLength: 1500
+
+      # Expose the result as the workflow's output for callers / composing workflows.
+      - name: output_result
+        type: workflow.output
+        with:
+          status: "investigated"
+          resource: "{{ steps.resolve.output.function_name }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          classification: "{{ steps.classify_lambda_pattern.output.category }}"
+          rationale: "{{ steps.classify_lambda_pattern.output.rationale }}"
+          summary: "{{ steps.synthesize_findings.output.content }}"
+
+    else:
+      - name: output_insufficient_evidence
+        type: workflow.output
+        with:
+          status: "insufficient_evidence"
+          resource: "{{ steps.resolve.output.function_name }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          summary: >-
+            No Lambda datapoints found for "{{ steps.resolve.output.function_name }}"
+            in the incident window around {{ steps.resolve.output.alert_timestamp }}.
+            Either the function name could not be resolved (manual input missing, or the
+            triggering alert's group carries no FunctionName), the metrics have not been
+            ingested yet, or the name does not match this cluster's data. Refusing to
+            produce a diagnosis without evidence.

--- a/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
+++ b/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
@@ -119,6 +119,7 @@ steps:
           categories:
             - elevated_errors
             - throttling
+            - load_surge
             - duration_degradation
             - healthy
           instructions: |
@@ -128,12 +129,20 @@ steps:
               - elevated_errors: error_rate is MATERIALLY above baseline_error_rate (roughly
                 2x or more, or a jump of many percentage points) with few/no throttles —
                 the function code/dependency is failing.
-              - duration_degradation: error_rate near baseline but max_duration sharply up — the
-                function is slow (downstream latency / cold starts / resource limits).
+              - load_surge: incident invocations are sharply above baseline (roughly 3x or
+                more) while error_rate stays near baseline and throttles are ~0 — the
+                function is absorbing a traffic surge, not failing. Absolute error COUNTS
+                rise with volume even at a healthy rate, which is often what tripped the
+                alert or burned SLO error budget; say so rather than inventing a code failure.
+              - duration_degradation: error_rate near baseline but max_duration is MATERIALLY
+                above baseline (roughly 1.5x or more) — the function is slow (downstream
+                latency / cold starts / resource limits). Small duration wiggles of a few
+                percent — especially during a load surge — are ambient, NOT degradation.
               - healthy: error_rate within normal fluctuation of baseline (small drifts of a
                 couple of percentage points are ambient noise, NOT an incident), no throttles,
-                duration stable.
-            Pick the single best category; prefer throttling when throttles > 0.
+                invocations near baseline, duration stable.
+            Pick the single best category. Precedence when several apply: throttling first
+            (throttles > 0), then elevated_errors, then load_surge, then duration_degradation.
             A null error_rate means zero invocations in the window — do not read it as 0%;
             if invocations are zero while throttles are high, that IS the throttling pattern.
             If the baseline returned no rows or nulls, note the comparison is unavailable —
@@ -198,8 +207,10 @@ steps:
             CAUSAL CHAIN — adjust to the evidence (e.g. arrival spike → concurrency exhausted →
               throttles → dropped/failed invocations; or a failing dependency → error rate up).
             RECOMMENDED NEXT STEPS — e.g. raise reserved/provisioned concurrency for throttling;
-              inspect function logs / the failing dependency for elevated_errors; profile cold
-              starts / downstream calls for duration_degradation.
+              inspect function logs / the failing dependency for elevated_errors; for load_surge,
+              identify the traffic source, confirm concurrency headroom, and consider whether the
+              alert threshold should be rate-based for this workload; profile cold starts /
+              downstream calls for duration_degradation.
             DOWNSTREAM IMPACT — what the failed/throttled invocations affect.
             CONFIDENCE NOTE — only if ambiguous.
           maxLength: 1500

--- a/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
+++ b/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
@@ -1,0 +1,169 @@
+template-metadata:
+  slug: aws-lambda-errors-investigation-otel
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "AWS Lambda error spike investigation (OTel)"
+  description: >-
+    Investigate a Lambda function with an elevated failure rate. Correlates
+    Errors, Invocations, Throttles, Duration, and ConcurrentExecutions to
+    distinguish failing code, concurrency throttling, or duration degradation.
+    Requires AWS OTel metrics from the EDOT awscloudwatch collector
+    (metrics-aws.*.otel-*).
+  solutions: [observability]
+  categories: [root-cause-analysis, monitoring]
+
+name: AWS Lambda Error Spike Investigation (OTel)
+description: >
+  Automated investigation of a Lambda function with an elevated failure rate. Decides
+  whether the function is FAILING (Errors up vs baseline), being THROTTLED (concurrency
+  exhausted), or DEGRADING (Duration climbing), by correlating Errors/Invocations/
+  Throttles/Duration/ConcurrentExecutions. Built against OTel-schema AWS CloudWatch
+  metrics from the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
+
+consts:
+  lambda_metrics_index: "metrics-aws.lambda.otel-*"
+  baseline_lookback: "45 minutes"
+  baseline_lookend: "12 minutes"
+  incident_lookback: "20 minutes"
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: function_name
+        type: string
+        description: >-
+          Lambda FunctionName of the alerting function (e.g. fis-worker-fns-0).
+        required: true
+      - name: alert_timestamp
+        type: string
+        description: ISO8601 timestamp of the alert firing.
+        required: true
+
+steps:
+  # 1. Failure signals during the incident: errors, the error RATE (errors/invocations),
+  #    throttles, peak concurrency, and slowest duration.
+  - name: errors_incident
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.lambda_metrics_index }}
+        | WHERE attributes.FunctionName == "{{ inputs.function_name }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            errors       = SUM(`metrics.amazonaws.com/AWS/Lambda/Errors`),
+            invocations  = SUM(`metrics.amazonaws.com/AWS/Lambda/Invocations`),
+            throttles    = SUM(`metrics.amazonaws.com/AWS/Lambda/Throttles`),
+            max_duration = MAX(`metrics.amazonaws.com/AWS/Lambda/Duration`),
+            max_concurrency = MAX(`metrics.amazonaws.com/AWS/Lambda/ConcurrentExecutions`)
+        | EVAL error_rate = TO_DOUBLE(errors) / TO_DOUBLE(invocations + 1)
+      format: json
+    on-failure:
+      continue: true
+
+  # 2. Baseline failure rate BEFORE the incident.
+  - name: errors_baseline
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.lambda_metrics_index }}
+        | WHERE attributes.FunctionName == "{{ inputs.function_name }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | STATS
+            errors      = SUM(`metrics.amazonaws.com/AWS/Lambda/Errors`),
+            invocations = SUM(`metrics.amazonaws.com/AWS/Lambda/Invocations`),
+            max_duration = MAX(`metrics.amazonaws.com/AWS/Lambda/Duration`)
+        | EVAL baseline_error_rate = TO_DOUBLE(errors) / TO_DOUBLE(invocations + 1)
+      format: json
+    on-failure:
+      continue: true
+
+  # 3. Classify the Lambda failure mode.
+  - name: classify_lambda_pattern
+    type: ai.classify
+    with:
+      input: |
+        FunctionName: {{ inputs.function_name }}
+        Incident: {{ steps.errors_incident.output | json }}
+        Baseline: {{ steps.errors_baseline.output | json }}
+      categories:
+        - elevated_errors
+        - throttling
+        - duration_degradation
+        - healthy
+      instructions: |
+        Classify the dominant Lambda failure mode:
+          - throttling: throttles > 0 and/or max_concurrency pinned at a limit — invocations
+            are being rejected because concurrency is exhausted (scale / reserved-concurrency issue).
+          - elevated_errors: error_rate is well above baseline_error_rate with few/no throttles —
+            the function code/dependency is failing.
+          - duration_degradation: error_rate near baseline but max_duration sharply up — the
+            function is slow (downstream latency / cold starts / resource limits).
+          - healthy: error_rate near baseline, no throttles, duration stable.
+        Pick the single best category; prefer throttling when throttles > 0.
+      includeRationale: true
+
+  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+  - name: slo_context
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .slo-observability.summary-*
+        | WHERE slo.instanceId LIKE "*{{ inputs.function_name }}*"
+        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+      format: json
+    on-failure:
+      continue: true
+
+  - name: active_alerts
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .alerts-*
+        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.function_name }}*"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+        | SORT kibana.alert.start DESC
+        | LIMIT 20
+      format: json
+    on-failure:
+      continue: true
+
+  - name: synthesize_findings
+    type: ai.summarize
+    with:
+      input: |
+        ## Lambda incident investigation for {{ inputs.function_name }}
+        Alert timestamp: {{ inputs.alert_timestamp }}
+
+        Classification: {{ steps.classify_lambda_pattern.output.category }}
+        Rationale: {{ steps.classify_lambda_pattern.output.rationale }}
+
+        Incident: {{ steps.errors_incident.output | json }}
+        Baseline: {{ steps.errors_baseline.output | json }}
+        SLO status:    {{ steps.slo_context.output | json }}
+        Active alerts: {{ steps.active_alerts.output | json }}
+      instructions: |
+        You are an SRE assistant synthesising an AWS Lambda incident investigation.
+        Produce a structured root-cause summary in EXACTLY these sections:
+        ROOT CAUSE HYPOTHESIS — one sentence naming the dominant failure mode.
+        EVIDENCE — errors, invocations, error_rate vs baseline_error_rate, throttles,
+          max_concurrency, max_duration.
+        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+          materially consumed), or an alert is active for this resource, ANCHOR severity
+          and root cause on that calibrated signal and name the alert/SLO + its reason
+          (the shipped thresholds encode what is "bad" for this resource, which the raw
+          magnitude alone cannot establish). If no SLO/alert context is present or empty,
+          state the assessment rests on raw metrics alone with no SLO/alert corroboration
+          — do NOT invent one.
+        CAUSAL CHAIN — adjust to the evidence (e.g. arrival spike → concurrency exhausted →
+          throttles → dropped/failed invocations; or a failing dependency → error rate up).
+        RECOMMENDED NEXT STEPS — e.g. raise reserved/provisioned concurrency for throttling;
+          inspect function logs / the failing dependency for elevated_errors; profile cold
+          starts / downstream calls for duration_degradation.
+        DOWNSTREAM IMPACT — what the failed/throttled invocations affect.
+        CONFIDENCE NOTE — only if ambiguous.
+      maxLength: 1500

--- a/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
+++ b/library/workflows/aws-lambda-errors-investigation-otel/aws-lambda-errors-investigation-otel.yaml
@@ -28,27 +28,24 @@ consts:
   baseline_lookend: "20 minutes"
   incident_lookback: "20 minutes"
 
-# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
-# from the alert payload in the `resolve` step below.
-inputs:
-  - name: function_name
-    type: string
-    description: >-
-      Lambda FunctionName of the alerting function (e.g. fis-worker-fns-0).
-      Manual runs must supply it; alert-triggered runs derive it from the alert.
-    required: false
-  - name: alert_timestamp
-    type: string
-    description: >-
-      ISO8601 timestamp of the alert firing. Manual runs must supply it;
-      alert-triggered runs derive it from the alert.
-    required: false
-
 # The alert trigger fires only when a rule is connected to this workflow via the
 # "Run Workflow" rule action (.workflows system connector). Configure that action
 # with summaryMode:false so each run carries exactly ONE alert in event.alerts.
 triggers:
   - type: manual
+    inputs:
+      - name: function_name
+        type: string
+        description: >-
+          Lambda FunctionName of the alerting function (e.g. fis-worker-fns-0).
+          Manual runs must supply it; alert-triggered runs derive it from the alert.
+        required: false
+      - name: alert_timestamp
+        type: string
+        description: >-
+          ISO8601 timestamp of the alert firing. Manual runs must supply it;
+          alert-triggered runs derive it from the alert.
+        required: false
   - type: alert
 
 steps:

--- a/library/workflows/aws-rds-connection-exhaustion-investigation-otel/aws-rds-connection-exhaustion-investigation-otel.yaml
+++ b/library/workflows/aws-rds-connection-exhaustion-investigation-otel/aws-rds-connection-exhaustion-investigation-otel.yaml
@@ -39,33 +39,6 @@ consts:
   # Incident window padding around the alert timestamp.
   incident_lookback: "20 minutes"
 
-# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
-# from the alert payload in the `resolve` step below.
-inputs:
-  - name: db_instance_identifier
-    type: string
-    description: >-
-      RDS DBInstanceIdentifier of the alerting database (e.g. fis-orders-db-...).
-      Manual runs must supply it; alert-triggered runs derive it from the alert.
-    required: false
-  - name: service_name
-    type: string
-    description: >-
-      Application service that depends on the database (e.g. orders).
-    required: false
-  - name: load_balancer
-    type: string
-    description: >-
-      ApplicationELB dimension of the fronting ALB
-      (e.g. app/fis-demo-fleet-alb/<id>) for the 5xx cascade check.
-    required: false
-  - name: alert_timestamp
-    type: string
-    description: >-
-      ISO8601 timestamp of the alert firing. Manual runs must supply it;
-      alert-triggered runs derive it from the alert.
-    required: false
-
 # The alert trigger fires only when a rule is connected to this workflow via the
 # "Run Workflow" rule action (.workflows system connector). Configure that action
 # with summaryMode:false so each run carries exactly ONE alert in event.alerts —
@@ -73,6 +46,30 @@ inputs:
 # unrelated resources) and only the first would be investigated.
 triggers:
   - type: manual
+    inputs:
+      - name: db_instance_identifier
+        type: string
+        description: >-
+          RDS DBInstanceIdentifier of the alerting database (e.g. fis-orders-db-...).
+          Manual runs must supply it; alert-triggered runs derive it from the alert.
+        required: false
+      - name: service_name
+        type: string
+        description: >-
+          Application service that depends on the database (e.g. orders).
+        required: false
+      - name: load_balancer
+        type: string
+        description: >-
+          ApplicationELB dimension of the fronting ALB
+          (e.g. app/fis-demo-fleet-alb/<id>) for the 5xx cascade check.
+        required: false
+      - name: alert_timestamp
+        type: string
+        description: >-
+          ISO8601 timestamp of the alert firing. Manual runs must supply it;
+          alert-triggered runs derive it from the alert.
+        required: false
   - type: alert
 
 steps:

--- a/library/workflows/aws-rds-connection-exhaustion-investigation-otel/aws-rds-connection-exhaustion-investigation-otel.yaml
+++ b/library/workflows/aws-rds-connection-exhaustion-investigation-otel/aws-rds-connection-exhaustion-investigation-otel.yaml
@@ -1,0 +1,239 @@
+template-metadata:
+  slug: aws-rds-connection-exhaustion-investigation-otel
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "AWS RDS connection exhaustion investigation (OTel)"
+  description: >-
+    Investigate an RDS instance that is refusing new connections. Compares
+    incident vs baseline DatabaseConnections, rules out CPU/memory/IO/storage
+    bottlenecks, correlates with downstream ALB 5xx, and synthesises a
+    root-cause summary. Requires AWS OTel metrics from the EDOT awscloudwatch
+    collector (metrics-aws.*.otel-*).
+  solutions: [observability]
+  categories: [root-cause-analysis, monitoring]
+
+name: AWS RDS Connection Exhaustion Investigation (OTel)
+description: >
+  Automated investigation of an RDS database that is refusing new connections.
+  Confirms whether the database connection count climbed to its ceiling
+  (connection exhaustion) versus an alternative DB bottleneck (CPU, memory, IO,
+  storage), correlates with the downstream ALB 5xx cascade, and synthesises a
+  root-cause summary. Built against OTel-schema AWS CloudWatch metrics shipped by
+  the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
+
+# OTel-schema data streams produced by the EDOT awscloudwatch collector. The metric
+# value field is the CloudWatch name flattened under `metrics`, e.g.
+# `metrics.amazonaws.com/AWS/RDS/DatabaseConnections` — it contains dots and slashes,
+# so every reference is backticked in ES|QL.
+consts:
+  rds_metrics_index: "metrics-aws.rds.otel-*"
+  alb_metrics_index: "metrics-aws.applicationelb.otel-*"
+  # Baseline = the quiet period shortly BEFORE the alert. Kept recent (not -6h) so it
+  # works for short incidents and freshly-onboarded environments without deep history;
+  # widen for production databases with long stable baselines.
+  baseline_lookback: "45 minutes"
+  baseline_lookend: "12 minutes"
+  # Incident window padding around the alert timestamp.
+  incident_lookback: "20 minutes"
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: db_instance_identifier
+        type: string
+        description: >-
+          RDS DBInstanceIdentifier of the alerting database
+          (e.g. fis-orders-db-...).
+        required: true
+      - name: service_name
+        type: string
+        description: >-
+          Application service that depends on the database (e.g. orders).
+        required: true
+      - name: load_balancer
+        type: string
+        description: >-
+          ApplicationELB dimension of the fronting ALB
+          (e.g. app/fis-demo-fleet-alb/<id>) for the 5xx cascade check.
+        required: true
+      - name: alert_timestamp
+        type: string
+        description: ISO8601 timestamp of the alert firing.
+        required: true
+
+steps:
+  # 1. Connection count during the incident window: how high did it climb and did it plateau?
+  #    A plateau at a steady ceiling is the signature of pool/connection exhaustion.
+  - name: connections_incident
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.rds_metrics_index }}
+        | WHERE attributes.DBInstanceIdentifier == "{{ inputs.db_instance_identifier }}"
+          AND attributes.MetricName == "DatabaseConnections"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            peak_connections = MAX(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`),
+            avg_connections  = AVG(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`),
+            samples          = COUNT(*)
+      format: json
+    on-failure:
+      continue: true
+
+  # 2. Baseline connection count BEFORE the incident — the comparison denominator.
+  - name: connections_baseline
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.rds_metrics_index }}
+        | WHERE attributes.DBInstanceIdentifier == "{{ inputs.db_instance_identifier }}"
+          AND attributes.MetricName == "DatabaseConnections"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | STATS baseline_connections = AVG(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 3. Alternative DB bottlenecks — rule connection exhaustion IN by ruling these OUT.
+  #    If CPU/memory/IO are nominal while connections are pinned high, exhaustion is the cause.
+  - name: db_resource_metrics
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.rds_metrics_index }}
+        | WHERE attributes.DBInstanceIdentifier == "{{ inputs.db_instance_identifier }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            max_cpu_pct        = MAX(`metrics.amazonaws.com/AWS/RDS/CPUUtilization`),
+            min_freeable_mem   = MIN(`metrics.amazonaws.com/AWS/RDS/FreeableMemory`),
+            min_free_storage   = MIN(`metrics.amazonaws.com/AWS/RDS/FreeStorageSpace`),
+            max_read_latency   = MAX(`metrics.amazonaws.com/AWS/RDS/ReadLatency`),
+            max_write_latency  = MAX(`metrics.amazonaws.com/AWS/RDS/WriteLatency`),
+            max_disk_queue     = MAX(`metrics.amazonaws.com/AWS/RDS/DiskQueueDepth`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 4. Downstream cascade — causal chain often ends in ALB 5xx as the dependent
+  #    service times out waiting for a DB connection. Confirms blast radius.
+  - name: alb_cascade
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.alb_metrics_index }}
+        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            elb_5xx             = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count`),
+            request_count       = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`),
+            max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 5. Classify the database signal. The LLM weighs connection magnitude + plateau vs
+  #    the alternative-bottleneck metrics to pick the single dominant DB failure mode.
+  - name: classify_db_pattern
+    type: ai.classify
+    with:
+      input: |
+        DBInstanceIdentifier: {{ inputs.db_instance_identifier }}
+        Connections during incident: {{ steps.connections_incident.output | json }}
+        Baseline connections:        {{ steps.connections_baseline.output | json }}
+        DB resource metrics:         {{ steps.db_resource_metrics.output | json }}
+      categories:
+        - connection_exhaustion
+        - cpu_saturation
+        - memory_pressure
+        - io_latency
+        - storage_full
+        - unrecognized
+      instructions: |
+        You are classifying the dominant failure mode of an AWS RDS instance during an
+        incident. Note: RDS does NOT emit a max_connections metric, so connection
+        exhaustion is inferred from the symptom — DatabaseConnections climbing far above
+        baseline and plateauing at a steady ceiling while CPU, freeable memory, free
+        storage and IO latency remain within normal ranges. Choose:
+          - connection_exhaustion: peak connections >> baseline and plateaued, other resources nominal
+          - cpu_saturation: max_cpu_pct sustained near 100
+          - memory_pressure: min_freeable_mem near zero
+          - io_latency: read/write latency or disk queue depth sharply elevated
+          - storage_full: min_free_storage near zero
+        Pick the single best category. If signals are ambiguous, return "unrecognized".
+      includeRationale: true
+
+  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+  # The raw connection count can't say whether a value is "bad" for THIS instance (RDS
+  # emits no max_connections). Shipped SLOs + alert rules encode that judgement, so
+  # when present they anchor severity. on-failure:continue → missing index / undeployed
+  # object / no signal yields nothing and never breaks the run.
+  - name: slo_context
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .slo-observability.summary-*
+        | WHERE slo.instanceId LIKE "*{{ inputs.db_instance_identifier }}*"
+        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+      format: json
+    on-failure:
+      continue: true
+
+  - name: active_alerts
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .alerts-*
+        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.db_instance_identifier }}*"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+        | SORT kibana.alert.start DESC
+        | LIMIT 20
+      format: json
+    on-failure:
+      continue: true
+
+  # 6. Synthesise the root-cause summary.
+  - name: synthesize_findings
+    type: ai.summarize
+    with:
+      input: |
+        ## RDS incident investigation for {{ inputs.db_instance_identifier }}
+        Alert timestamp: {{ inputs.alert_timestamp }}
+        Dependent service: {{ inputs.service_name }}
+
+        Classification: {{ steps.classify_db_pattern.output.category }}
+        Rationale: {{ steps.classify_db_pattern.output.rationale }}
+
+        Connections (incident): {{ steps.connections_incident.output | json }}
+        Connections (baseline): {{ steps.connections_baseline.output | json }}
+        DB resource metrics:    {{ steps.db_resource_metrics.output | json }}
+        ALB cascade:            {{ steps.alb_cascade.output | json }}
+        SLO status:             {{ steps.slo_context.output | json }}
+        Active alerts:          {{ steps.active_alerts.output | json }}
+      instructions: |
+        You are an SRE assistant synthesising an AWS RDS incident investigation.
+        Produce a structured root-cause summary in EXACTLY these sections:
+        ROOT CAUSE HYPOTHESIS — one sentence naming the most likely cause.
+        EVIDENCE — the specific metric values supporting it (peak vs baseline
+          connections; the nominal/abnormal resource metrics; ALB 5xx + latency).
+        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+          materially consumed), or an alert is active for this resource, ANCHOR the
+          severity and root cause on that calibrated signal and name the alert/SLO + its
+          reason (e.g. the "Database connections high" alert confirms the count is high
+          for THIS instance — which the raw number alone cannot establish). If no
+          SLO/alert context is present or it shows nothing, state the assessment rests on
+          raw metrics alone with no SLO/alert corroboration — do NOT invent one.
+        CAUSAL CHAIN — connections climb to the ceiling → new connections refused →
+          {{ inputs.service_name }} times out → 5xx at the ALB (adjust to the evidence).
+        RECOMMENDED NEXT STEPS — e.g. drain/recycle leaked connections, raise the
+          connection ceiling (max_connections / pool size) with headroom, restart
+          {{ inputs.service_name }} to reset its pool, fix the leak.
+        DOWNSTREAM IMPACT — services affected and user-facing symptom.
+        CONFIDENCE NOTE — only if the classification was ambiguous.
+      maxLength: 1500

--- a/library/workflows/aws-rds-connection-exhaustion-investigation-otel/aws-rds-connection-exhaustion-investigation-otel.yaml
+++ b/library/workflows/aws-rds-connection-exhaustion-investigation-otel/aws-rds-connection-exhaustion-investigation-otel.yaml
@@ -27,60 +27,87 @@ description: >
 # so every reference is backticked in ES|QL.
 consts:
   rds_metrics_index: "metrics-aws.rds.otel-*"
-  alb_metrics_index: "metrics-aws.applicationelb.otel-*"
-  # Baseline = the quiet period shortly BEFORE the alert. Kept recent (not -6h) so it
-  # works for short incidents and freshly-onboarded environments without deep history;
-  # widen for production databases with long stable baselines.
-  baseline_lookback: "45 minutes"
-  baseline_lookend: "12 minutes"
+  # `elb` is the canonical dataset of the aws_elb_metrics_otel package (its alert
+  # templates and dashboard all read metrics-aws.elb.otel-*).
+  alb_metrics_index: "metrics-aws.elb.otel-*"
+  # Baseline = the quiet period ENDING where the incident window begins (T-50m..T-20m
+  # vs incident T-20m..T+5m — no overlap, or incident data would contaminate the
+  # baseline). Kept recent (not -6h) so it works for short incidents and freshly-
+  # onboarded environments without deep history; widen for long stable baselines.
+  baseline_lookback: "50 minutes"
+  baseline_lookend: "20 minutes"
   # Incident window padding around the alert timestamp.
   incident_lookback: "20 minutes"
 
+# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
+# from the alert payload in the `resolve` step below.
+inputs:
+  - name: db_instance_identifier
+    type: string
+    description: >-
+      RDS DBInstanceIdentifier of the alerting database (e.g. fis-orders-db-...).
+      Manual runs must supply it; alert-triggered runs derive it from the alert.
+    required: false
+  - name: service_name
+    type: string
+    description: >-
+      Application service that depends on the database (e.g. orders).
+    required: false
+  - name: load_balancer
+    type: string
+    description: >-
+      ApplicationELB dimension of the fronting ALB
+      (e.g. app/fis-demo-fleet-alb/<id>) for the 5xx cascade check.
+    required: false
+  - name: alert_timestamp
+    type: string
+    description: >-
+      ISO8601 timestamp of the alert firing. Manual runs must supply it;
+      alert-triggered runs derive it from the alert.
+    required: false
+
+# The alert trigger fires only when a rule is connected to this workflow via the
+# "Run Workflow" rule action (.workflows system connector). Configure that action
+# with summaryMode:false so each run carries exactly ONE alert in event.alerts —
+# with summaryMode:true a single run can carry several alerts (possibly for
+# unrelated resources) and only the first would be investigated.
 triggers:
-  - type: alert
   - type: manual
-    inputs:
-      - name: db_instance_identifier
-        type: string
-        description: >-
-          RDS DBInstanceIdentifier of the alerting database
-          (e.g. fis-orders-db-...).
-        required: true
-      - name: service_name
-        type: string
-        description: >-
-          Application service that depends on the database (e.g. orders).
-        required: true
-      - name: load_balancer
-        type: string
-        description: >-
-          ApplicationELB dimension of the fronting ALB
-          (e.g. app/fis-demo-fleet-alb/<id>) for the 5xx cascade check.
-        required: true
-      - name: alert_timestamp
-        type: string
-        description: ISO8601 timestamp of the alert firing.
-        required: true
+  - type: alert
 
 steps:
-  # 1. Connection count during the incident window: how high did it climb and did it plateau?
-  #    A plateau at a steady ceiling is the signature of pool/connection exhaustion.
+  # 0. Resolve the target + timestamp: manual inputs win; otherwise the triggering
+  #    alert's structured group-by fields name the resource (kibana.alert.grouping.*)
+  #    and kibana.alert.start is the firing time. "MISSING" is a sentinel that makes
+  #    the incident query match nothing, so the evidence gate below aborts cleanly
+  #    (e.g. an alert on a null/degenerate ES|QL group carries no resource id).
+  - name: resolve
+    type: data.set
+    with:
+      db_instance_identifier: "{{ inputs.db_instance_identifier | default: event.alerts[0].kibana.alert.grouping.DBInstanceIdentifier | default: 'MISSING' }}"
+      alert_timestamp: "{{ inputs.alert_timestamp | default: event.alerts[0].kibana.alert.start | default: 'MISSING' }}"
+      service_name: "{{ inputs.service_name | default: 'unknown' }}"
+      load_balancer: "{{ inputs.load_balancer | default: 'MISSING' }}"
+      triggering_rule: "{{ event.rule.name | default: 'manual run' }}"
+
+  # 1. Connection count during the incident window: how high did it climb and did it
+  #    plateau? A plateau at a steady ceiling is the signature of pool/connection
+  #    exhaustion. REQUIRED evidence: a query failure fails the whole run rather than
+  #    feeding empty output into the classifier.
   - name: connections_incident
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.rds_metrics_index }}
-        | WHERE attributes.DBInstanceIdentifier == "{{ inputs.db_instance_identifier }}"
+        | WHERE attributes.DBInstanceIdentifier == "{{ steps.resolve.output.db_instance_identifier }}"
           AND attributes.MetricName == "DatabaseConnections"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            peak_connections = MAX(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`),
-            avg_connections  = AVG(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`),
+            peak_connections = MAX(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`) WHERE attributes.stat == "Maximum",
+            avg_connections  = AVG(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`) WHERE attributes.stat == "Average",
             samples          = COUNT(*)
       format: json
-    on-failure:
-      continue: true
 
   # 2. Baseline connection count BEFORE the incident — the comparison denominator.
   - name: connections_baseline
@@ -88,14 +115,12 @@ steps:
     with:
       query: |
         FROM {{ consts.rds_metrics_index }}
-        | WHERE attributes.DBInstanceIdentifier == "{{ inputs.db_instance_identifier }}"
+        | WHERE attributes.DBInstanceIdentifier == "{{ steps.resolve.output.db_instance_identifier }}"
           AND attributes.MetricName == "DatabaseConnections"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
-        | STATS baseline_connections = AVG(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`)
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | STATS baseline_connections = AVG(`metrics.amazonaws.com/AWS/RDS/DatabaseConnections`) WHERE attributes.stat == "Average"
       format: json
-    on-failure:
-      continue: true
 
   # 3. Alternative DB bottlenecks — rule connection exhaustion IN by ruling these OUT.
   #    If CPU/memory/IO are nominal while connections are pinned high, exhaustion is the cause.
@@ -104,136 +129,175 @@ steps:
     with:
       query: |
         FROM {{ consts.rds_metrics_index }}
-        | WHERE attributes.DBInstanceIdentifier == "{{ inputs.db_instance_identifier }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | WHERE attributes.DBInstanceIdentifier == "{{ steps.resolve.output.db_instance_identifier }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            max_cpu_pct        = MAX(`metrics.amazonaws.com/AWS/RDS/CPUUtilization`),
-            min_freeable_mem   = MIN(`metrics.amazonaws.com/AWS/RDS/FreeableMemory`),
-            min_free_storage   = MIN(`metrics.amazonaws.com/AWS/RDS/FreeStorageSpace`),
-            max_read_latency   = MAX(`metrics.amazonaws.com/AWS/RDS/ReadLatency`),
-            max_write_latency  = MAX(`metrics.amazonaws.com/AWS/RDS/WriteLatency`),
-            max_disk_queue     = MAX(`metrics.amazonaws.com/AWS/RDS/DiskQueueDepth`)
+            max_cpu_pct        = MAX(`metrics.amazonaws.com/AWS/RDS/CPUUtilization`)    WHERE attributes.stat == "Maximum",
+            min_freeable_mem   = MIN(`metrics.amazonaws.com/AWS/RDS/FreeableMemory`)    WHERE attributes.stat == "Average",
+            min_free_storage   = MIN(`metrics.amazonaws.com/AWS/RDS/FreeStorageSpace`)  WHERE attributes.stat == "Average",
+            max_read_latency   = MAX(`metrics.amazonaws.com/AWS/RDS/ReadLatency`)       WHERE attributes.stat == "Maximum",
+            max_write_latency  = MAX(`metrics.amazonaws.com/AWS/RDS/WriteLatency`)      WHERE attributes.stat == "Maximum",
+            max_disk_queue     = MAX(`metrics.amazonaws.com/AWS/RDS/DiskQueueDepth`)    WHERE attributes.stat == "Maximum"
       format: json
-    on-failure:
-      continue: true
 
-  # 4. Downstream cascade — causal chain often ends in ALB 5xx as the dependent
-  #    service times out waiting for a DB connection. Confirms blast radius.
+  # 4. Downstream cascade — causal chain often ends in ALB TARGET 5xx as the dependent
+  #    service times out waiting for a DB connection and returns 503. Confirms blast
+  #    radius. OPTIONAL: the ALB may not be onboarded, and HTTPCode_Target_5XX_Count is a
+  #    SPARSE CloudWatch metric (unmapped until the first 5xx ever lands, and ES|QL fails
+  #    verification on an unknown column) — continue without it.
   - name: alb_cascade
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.alb_metrics_index }}
-        | WHERE attributes.LoadBalancer == "{{ inputs.load_balancer }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | WHERE attributes.LoadBalancer == "{{ steps.resolve.output.load_balancer }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            elb_5xx             = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count`),
-            request_count       = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`),
-            max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`)
+            target_5xx          = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count`) WHERE attributes.stat == "Sum",
+            request_count       = SUM(`metrics.amazonaws.com/AWS/ApplicationELB/RequestCount`)              WHERE attributes.stat == "Sum",
+            max_target_response = MAX(`metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime`)        WHERE attributes.stat == "Maximum"
       format: json
     on-failure:
       continue: true
 
-  # 5. Classify the database signal. The LLM weighs connection magnitude + plateau vs
-  #    the alternative-bottleneck metrics to pick the single dominant DB failure mode.
-  - name: classify_db_pattern
-    type: ai.classify
-    with:
-      input: |
-        DBInstanceIdentifier: {{ inputs.db_instance_identifier }}
-        Connections during incident: {{ steps.connections_incident.output | json }}
-        Baseline connections:        {{ steps.connections_baseline.output | json }}
-        DB resource metrics:         {{ steps.db_resource_metrics.output | json }}
-      categories:
-        - connection_exhaustion
-        - cpu_saturation
-        - memory_pressure
-        - io_latency
-        - storage_full
-        - unrecognized
-      instructions: |
-        You are classifying the dominant failure mode of an AWS RDS instance during an
-        incident. Note: RDS does NOT emit a max_connections metric, so connection
-        exhaustion is inferred from the symptom — DatabaseConnections climbing far above
-        baseline and plateauing at a steady ceiling while CPU, freeable memory, free
-        storage and IO latency remain within normal ranges. Choose:
-          - connection_exhaustion: peak connections >> baseline and plateaued, other resources nominal
-          - cpu_saturation: max_cpu_pct sustained near 100
-          - memory_pressure: min_freeable_mem near zero
-          - io_latency: read/write latency or disk queue depth sharply elevated
-          - storage_full: min_free_storage near zero
-        Pick the single best category. If signals are ambiguous, return "unrecognized".
-      includeRationale: true
+  # 5. Evidence gate — deterministic, BEFORE any AI step. If the incident window has
+  #    zero datapoints for the resolved resource (wrong/missing resource name, data not
+  #    yet ingested, degenerate alert group), refuse to diagnose instead of letting the
+  #    classifier see a row of nulls and return a plausible-but-unsupported verdict.
+  - name: evidence_gate
+    type: if
+    condition: "steps.connections_incident.output.documents_found > 0"
+    steps:
+      # 6. Classify the database signal. The LLM weighs connection magnitude + plateau vs
+      #    the alternative-bottleneck metrics to pick the single dominant DB failure mode.
+      - name: classify_db_pattern
+        type: ai.classify
+        with:
+          input: |
+            DBInstanceIdentifier: {{ steps.resolve.output.db_instance_identifier }}
+            Connections during incident: {{ steps.connections_incident.output | json }}
+            Baseline connections:        {{ steps.connections_baseline.output | json }}
+            DB resource metrics:         {{ steps.db_resource_metrics.output | json }}
+          categories:
+            - connection_exhaustion
+            - cpu_saturation
+            - memory_pressure
+            - io_latency
+            - storage_full
+            - unrecognized
+          instructions: |
+            You are classifying the dominant failure mode of an AWS RDS instance during an
+            incident. Note: RDS does NOT emit a max_connections metric, so connection
+            exhaustion is inferred from the symptom — DatabaseConnections climbing far above
+            baseline and plateauing at a steady ceiling while CPU, freeable memory, free
+            storage and IO latency remain within normal ranges. Choose:
+              - connection_exhaustion: peak connections >> baseline and plateaued, other resources nominal
+              - cpu_saturation: max_cpu_pct sustained near 100
+              - memory_pressure: min_freeable_mem near zero
+              - io_latency: read/write latency or disk queue depth sharply elevated
+              - storage_full: min_free_storage near zero
+            Pick the single best category. If signals are ambiguous, return "unrecognized".
+            If the baseline query returned no rows or nulls, note that the comparison is
+            unavailable — do not treat a missing baseline as a zero baseline.
+          includeRationale: true
 
-  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
-  # The raw connection count can't say whether a value is "bad" for THIS instance (RDS
-  # emits no max_connections). Shipped SLOs + alert rules encode that judgement, so
-  # when present they anchor severity. on-failure:continue → missing index / undeployed
-  # object / no signal yields nothing and never breaks the run.
-  - name: slo_context
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .slo-observability.summary-*
-        | WHERE slo.instanceId LIKE "*{{ inputs.db_instance_identifier }}*"
-        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
-      format: json
-    on-failure:
-      continue: true
+      # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+      # The raw connection count can't say whether a value is "bad" for THIS instance (RDS
+      # emits no max_connections). Shipped SLOs + alert rules encode that judgement, so
+      # when present they anchor severity. on-failure:continue → missing index / undeployed
+      # object / no signal yields nothing and never breaks the run.
+      - name: slo_context
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .slo-observability.summary-*
+            | WHERE slo.instanceId LIKE "*{{ steps.resolve.output.db_instance_identifier }}*"
+            | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+          format: json
+        on-failure:
+          continue: true
 
-  - name: active_alerts
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .alerts-*
-        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.db_instance_identifier }}*"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
-        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
-        | SORT kibana.alert.start DESC
-        | LIMIT 20
-      format: json
-    on-failure:
-      continue: true
+      - name: active_alerts
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .alerts-*
+            | WHERE kibana.alert.instance.id LIKE "*{{ steps.resolve.output.db_instance_identifier }}*"
+              AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+              AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+            | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+            | SORT kibana.alert.start DESC
+            | LIMIT 20
+          format: json
+        on-failure:
+          continue: true
 
-  # 6. Synthesise the root-cause summary.
-  - name: synthesize_findings
-    type: ai.summarize
-    with:
-      input: |
-        ## RDS incident investigation for {{ inputs.db_instance_identifier }}
-        Alert timestamp: {{ inputs.alert_timestamp }}
-        Dependent service: {{ inputs.service_name }}
+      # 7. Synthesise the root-cause summary.
+      - name: synthesize_findings
+        type: ai.summarize
+        with:
+          input: |
+            ## RDS incident investigation for {{ steps.resolve.output.db_instance_identifier }}
+            Alert timestamp: {{ steps.resolve.output.alert_timestamp }}
+            Triggered by: {{ steps.resolve.output.triggering_rule }}
+            Dependent service: {{ steps.resolve.output.service_name }}
 
-        Classification: {{ steps.classify_db_pattern.output.category }}
-        Rationale: {{ steps.classify_db_pattern.output.rationale }}
+            Classification: {{ steps.classify_db_pattern.output.category }}
+            Rationale: {{ steps.classify_db_pattern.output.rationale }}
 
-        Connections (incident): {{ steps.connections_incident.output | json }}
-        Connections (baseline): {{ steps.connections_baseline.output | json }}
-        DB resource metrics:    {{ steps.db_resource_metrics.output | json }}
-        ALB cascade:            {{ steps.alb_cascade.output | json }}
-        SLO status:             {{ steps.slo_context.output | json }}
-        Active alerts:          {{ steps.active_alerts.output | json }}
-      instructions: |
-        You are an SRE assistant synthesising an AWS RDS incident investigation.
-        Produce a structured root-cause summary in EXACTLY these sections:
-        ROOT CAUSE HYPOTHESIS — one sentence naming the most likely cause.
-        EVIDENCE — the specific metric values supporting it (peak vs baseline
-          connections; the nominal/abnormal resource metrics; ALB 5xx + latency).
-        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
-          materially consumed), or an alert is active for this resource, ANCHOR the
-          severity and root cause on that calibrated signal and name the alert/SLO + its
-          reason (e.g. the "Database connections high" alert confirms the count is high
-          for THIS instance — which the raw number alone cannot establish). If no
-          SLO/alert context is present or it shows nothing, state the assessment rests on
-          raw metrics alone with no SLO/alert corroboration — do NOT invent one.
-        CAUSAL CHAIN — connections climb to the ceiling → new connections refused →
-          {{ inputs.service_name }} times out → 5xx at the ALB (adjust to the evidence).
-        RECOMMENDED NEXT STEPS — e.g. drain/recycle leaked connections, raise the
-          connection ceiling (max_connections / pool size) with headroom, restart
-          {{ inputs.service_name }} to reset its pool, fix the leak.
-        DOWNSTREAM IMPACT — services affected and user-facing symptom.
-        CONFIDENCE NOTE — only if the classification was ambiguous.
-      maxLength: 1500
+            Connections (incident): {{ steps.connections_incident.output | json }}
+            Connections (baseline): {{ steps.connections_baseline.output | json }}
+            DB resource metrics:    {{ steps.db_resource_metrics.output | json }}
+            ALB cascade:            {{ steps.alb_cascade.output | json }}
+            SLO status:             {{ steps.slo_context.output | json }}
+            Active alerts:          {{ steps.active_alerts.output | json }}
+          instructions: |
+            You are an SRE assistant synthesising an AWS RDS incident investigation.
+            Produce a structured root-cause summary in EXACTLY these sections:
+            ROOT CAUSE HYPOTHESIS — one sentence naming the most likely cause.
+            EVIDENCE — the specific metric values supporting it (peak vs baseline
+              connections; the nominal/abnormal resource metrics; ALB 5xx + latency).
+            SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+              materially consumed), or an alert is active for this resource, ANCHOR the
+              severity and root cause on that calibrated signal and name the alert/SLO + its
+              reason (e.g. the "Database connections high" alert confirms the count is high
+              for THIS instance — which the raw number alone cannot establish). If no
+              SLO/alert context is present or it shows nothing, state the assessment rests on
+              raw metrics alone with no SLO/alert corroboration — do NOT invent one.
+            CAUSAL CHAIN — connections climb to the ceiling → new connections refused →
+              the dependent service times out → 5xx at the ALB (adjust to the evidence).
+            RECOMMENDED NEXT STEPS — e.g. drain/recycle leaked connections, raise the
+              connection ceiling (max_connections / pool size) with headroom, restart
+              the dependent service to reset its pool, fix the leak.
+            DOWNSTREAM IMPACT — services affected and user-facing symptom.
+            CONFIDENCE NOTE — only if the classification was ambiguous.
+          maxLength: 1500
+
+      # 8. Expose the result as the workflow's output so callers / composing
+      #    workflows can consume it (not just read a step output).
+      - name: output_result
+        type: workflow.output
+        with:
+          status: "investigated"
+          resource: "{{ steps.resolve.output.db_instance_identifier }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          classification: "{{ steps.classify_db_pattern.output.category }}"
+          rationale: "{{ steps.classify_db_pattern.output.rationale }}"
+          summary: "{{ steps.synthesize_findings.output.content }}"
+
+    else:
+      - name: output_insufficient_evidence
+        type: workflow.output
+        with:
+          status: "insufficient_evidence"
+          resource: "{{ steps.resolve.output.db_instance_identifier }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          summary: >-
+            No RDS datapoints found for "{{ steps.resolve.output.db_instance_identifier }}"
+            in the incident window around {{ steps.resolve.output.alert_timestamp }}.
+            Either the resource identifier could not be resolved (manual input missing, or
+            the triggering alert's group carries no DBInstanceIdentifier), the metrics have
+            not been ingested yet, or the identifier does not match this cluster's data.
+            Refusing to produce a diagnosis without evidence.

--- a/library/workflows/aws-sqs-consumer-lag-investigation-otel/aws-sqs-consumer-lag-investigation-otel.yaml
+++ b/library/workflows/aws-sqs-consumer-lag-investigation-otel/aws-sqs-consumer-lag-investigation-otel.yaml
@@ -1,0 +1,198 @@
+template-metadata:
+  slug: aws-sqs-consumer-lag-investigation-otel
+  version: "1.0.0"
+  availability: ">=9.5.0"
+  name: "AWS SQS consumer lag investigation (OTel)"
+  description: >-
+    Investigate an SQS queue whose backlog is growing. Correlates visible-message
+    backlog, oldest-message age, and sent-vs-deleted throughput to distinguish
+    consumer lag, a stalled consumer, or a producer spike. Requires AWS OTel
+    metrics from the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
+  solutions: [observability]
+  categories: [root-cause-analysis, monitoring]
+
+name: AWS SQS Consumer Lag Investigation (OTel)
+description: >
+  Automated investigation of an SQS queue whose backlog is growing. Confirms
+  whether the queue is backing up because the consumer can't keep up (consumer
+  lag), the consumer has stalled entirely, or producers spiked — by correlating
+  the visible-message backlog, the age of the oldest message, and the sent-vs-
+  deleted throughput balance. Built against OTel-schema AWS CloudWatch metrics
+  shipped by the EDOT awscloudwatch collector (metrics-aws.*.otel-*).
+
+# OTel-schema SQS data stream. Metric value field is the CloudWatch name flattened
+# under `metrics` (dots + slashes), so every reference is backticked in ES|QL.
+consts:
+  sqs_metrics_index: "metrics-aws.sqs.otel-*"
+  # Baseline = the quiet period shortly BEFORE the alert (kept recent so it works for
+  # short incidents / freshly-onboarded environments; widen for long stable baselines).
+  baseline_lookback: "45 minutes"
+  baseline_lookend: "12 minutes"
+  incident_lookback: "20 minutes"
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: queue_name
+        type: string
+        description: >-
+          SQS QueueName of the alerting queue (e.g. fis-order-events).
+        required: true
+      - name: service_name
+        type: string
+        description: >-
+          The consumer service that drains the queue (e.g. fulfillment-worker).
+        required: true
+      - name: alert_timestamp
+        type: string
+        description: ISO8601 timestamp of the alert firing.
+        required: true
+
+steps:
+  # 1. Backlog + lag during the incident: did the visible-message count and the age of
+  #    the oldest message climb? That pair is the signature of the queue backing up.
+  - name: backlog_incident
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.sqs_metrics_index }}
+        | WHERE attributes.QueueName == "{{ inputs.queue_name }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            peak_visible    = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`),
+            avg_visible     = AVG(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`),
+            peak_oldest_age = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateAgeOfOldestMessage`),
+            peak_in_flight  = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesNotVisible`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 2. Baseline backlog BEFORE the incident — the comparison denominator.
+  - name: backlog_baseline
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.sqs_metrics_index }}
+        | WHERE attributes.QueueName == "{{ inputs.queue_name }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | STATS baseline_visible = AVG(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 3. Throughput balance — sent vs deleted vs received. If sent outpaces deleted, the
+  #    producer is arriving faster than the consumer drains; if deleted ~ 0 while sent
+  #    continues, the consumer has stalled entirely.
+  - name: throughput_balance
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM {{ consts.sqs_metrics_index }}
+        | WHERE attributes.QueueName == "{{ inputs.queue_name }}"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | STATS
+            sent     = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesSent`),
+            deleted  = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesDeleted`),
+            received = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesReceived`),
+            empty_receives = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfEmptyReceives`)
+      format: json
+    on-failure:
+      continue: true
+
+  # 4. Classify the queue failure mode from backlog growth + throughput balance.
+  - name: classify_queue_pattern
+    type: ai.classify
+    with:
+      input: |
+        QueueName: {{ inputs.queue_name }}
+        Backlog during incident: {{ steps.backlog_incident.output | json }}
+        Baseline backlog:        {{ steps.backlog_baseline.output | json }}
+        Throughput balance:      {{ steps.throughput_balance.output | json }}
+      categories:
+        - consumer_lag
+        - consumer_stalled
+        - producer_spike
+        - healthy
+      instructions: |
+        Classify why the SQS queue backlog is behaving as it is:
+          - consumer_lag: peak_visible and peak_oldest_age climb well above baseline,
+            and `deleted` is non-zero but LOWER than `sent` — the consumer is draining
+            but can't keep up with the arrival rate.
+          - consumer_stalled: backlog and oldest-age climb sharply while `deleted` is
+            ~0 (and `empty_receives` may be ~0) — the consumer has stopped draining.
+          - producer_spike: `sent` is sharply elevated vs baseline and far exceeds
+            `deleted` — an arrival-rate surge is the dominant driver.
+          - healthy: peak_visible stays near baseline and oldest-age is low.
+        Pick the single best category. If signals are ambiguous, prefer the most
+        specific that fits (consumer_stalled over consumer_lag when deleted ~ 0).
+      includeRationale: true
+
+  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+  - name: slo_context
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .slo-observability.summary-*
+        | WHERE slo.instanceId LIKE "*{{ inputs.queue_name }}*"
+        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+      format: json
+    on-failure:
+      continue: true
+
+  - name: active_alerts
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM .alerts-*
+        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.queue_name }}*"
+          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+        | SORT kibana.alert.start DESC
+        | LIMIT 20
+      format: json
+    on-failure:
+      continue: true
+
+  - name: synthesize_findings
+    type: ai.summarize
+    with:
+      input: |
+        ## SQS incident investigation for {{ inputs.queue_name }}
+        Alert timestamp: {{ inputs.alert_timestamp }}
+        Consumer service: {{ inputs.service_name }}
+
+        Classification: {{ steps.classify_queue_pattern.output.category }}
+        Rationale: {{ steps.classify_queue_pattern.output.rationale }}
+
+        Backlog (incident): {{ steps.backlog_incident.output | json }}
+        Backlog (baseline): {{ steps.backlog_baseline.output | json }}
+        Throughput:         {{ steps.throughput_balance.output | json }}
+        SLO status:    {{ steps.slo_context.output | json }}
+        Active alerts: {{ steps.active_alerts.output | json }}
+      instructions: |
+        You are an SRE assistant synthesising an AWS SQS incident investigation.
+        Produce a structured root-cause summary in EXACTLY these sections:
+        ROOT CAUSE HYPOTHESIS — one sentence naming the most likely cause.
+        EVIDENCE — the specific values: peak vs baseline visible messages, oldest-message
+          age, and the sent-vs-deleted balance.
+        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+          materially consumed), or an alert is active for this resource, ANCHOR severity
+          and root cause on that calibrated signal and name the alert/SLO + its reason
+          (the shipped thresholds encode what is "bad" for this resource, which the raw
+          magnitude alone cannot establish). If no SLO/alert context is present or empty,
+          state the assessment rests on raw metrics alone with no SLO/alert corroboration
+          — do NOT invent one.
+        CAUSAL CHAIN — producers enqueue faster than {{ inputs.service_name }} drains →
+          backlog (visible messages) grows → oldest-message age rises → downstream
+          processing is delayed (adjust to the evidence).
+        RECOMMENDED NEXT STEPS — e.g. scale out {{ inputs.service_name }} consumer
+          concurrency / batch size to drain the backlog; shed or throttle producer load
+          until the queue recovers; check for a stalled or crash-looping consumer.
+        DOWNSTREAM IMPACT — what is delayed and the user-facing symptom.
+        CONFIDENCE NOTE — only if the classification was ambiguous.
+      maxLength: 1500

--- a/library/workflows/aws-sqs-consumer-lag-investigation-otel/aws-sqs-consumer-lag-investigation-otel.yaml
+++ b/library/workflows/aws-sqs-consumer-lag-investigation-otel/aws-sqs-consumer-lag-investigation-otel.yaml
@@ -30,32 +30,29 @@ consts:
   baseline_lookend: "20 minutes"
   incident_lookback: "20 minutes"
 
-# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
-# from the alert payload in the `resolve` step below.
-inputs:
-  - name: queue_name
-    type: string
-    description: >-
-      SQS QueueName of the alerting queue (e.g. fis-order-events).
-      Manual runs must supply it; alert-triggered runs derive it from the alert.
-    required: false
-  - name: service_name
-    type: string
-    description: >-
-      The consumer service that drains the queue (e.g. fulfillment-worker).
-    required: false
-  - name: alert_timestamp
-    type: string
-    description: >-
-      ISO8601 timestamp of the alert firing. Manual runs must supply it;
-      alert-triggered runs derive it from the alert.
-    required: false
-
 # The alert trigger fires only when a rule is connected to this workflow via the
 # "Run Workflow" rule action (.workflows system connector). Configure that action
 # with summaryMode:false so each run carries exactly ONE alert in event.alerts.
 triggers:
   - type: manual
+    inputs:
+      - name: queue_name
+        type: string
+        description: >-
+          SQS QueueName of the alerting queue (e.g. fis-order-events).
+          Manual runs must supply it; alert-triggered runs derive it from the alert.
+        required: false
+      - name: service_name
+        type: string
+        description: >-
+          The consumer service that drains the queue (e.g. fulfillment-worker).
+        required: false
+      - name: alert_timestamp
+        type: string
+        description: >-
+          ISO8601 timestamp of the alert firing. Manual runs must supply it;
+          alert-triggered runs derive it from the alert.
+        required: false
   - type: alert
 
 steps:

--- a/library/workflows/aws-sqs-consumer-lag-investigation-otel/aws-sqs-consumer-lag-investigation-otel.yaml
+++ b/library/workflows/aws-sqs-consumer-lag-investigation-otel/aws-sqs-consumer-lag-investigation-otel.yaml
@@ -24,50 +24,70 @@ description: >
 # under `metrics` (dots + slashes), so every reference is backticked in ES|QL.
 consts:
   sqs_metrics_index: "metrics-aws.sqs.otel-*"
-  # Baseline = the quiet period shortly BEFORE the alert (kept recent so it works for
-  # short incidents / freshly-onboarded environments; widen for long stable baselines).
-  baseline_lookback: "45 minutes"
-  baseline_lookend: "12 minutes"
+  # Baseline T-50m..T-20m vs incident T-20m..T+5m — windows must NOT overlap or
+  # incident data contaminates the baseline comparison.
+  baseline_lookback: "50 minutes"
+  baseline_lookend: "20 minutes"
   incident_lookback: "20 minutes"
 
+# Inputs are optional: manual runs supply them; alert-triggered runs resolve them
+# from the alert payload in the `resolve` step below.
+inputs:
+  - name: queue_name
+    type: string
+    description: >-
+      SQS QueueName of the alerting queue (e.g. fis-order-events).
+      Manual runs must supply it; alert-triggered runs derive it from the alert.
+    required: false
+  - name: service_name
+    type: string
+    description: >-
+      The consumer service that drains the queue (e.g. fulfillment-worker).
+    required: false
+  - name: alert_timestamp
+    type: string
+    description: >-
+      ISO8601 timestamp of the alert firing. Manual runs must supply it;
+      alert-triggered runs derive it from the alert.
+    required: false
+
+# The alert trigger fires only when a rule is connected to this workflow via the
+# "Run Workflow" rule action (.workflows system connector). Configure that action
+# with summaryMode:false so each run carries exactly ONE alert in event.alerts.
 triggers:
-  - type: alert
   - type: manual
-    inputs:
-      - name: queue_name
-        type: string
-        description: >-
-          SQS QueueName of the alerting queue (e.g. fis-order-events).
-        required: true
-      - name: service_name
-        type: string
-        description: >-
-          The consumer service that drains the queue (e.g. fulfillment-worker).
-        required: true
-      - name: alert_timestamp
-        type: string
-        description: ISO8601 timestamp of the alert firing.
-        required: true
+  - type: alert
 
 steps:
+  # 0. Resolve the target + timestamp: manual inputs win; otherwise the triggering
+  #    alert's structured group-by fields (kibana.alert.grouping.*) name the resource
+  #    and kibana.alert.start is the firing time. "MISSING" makes the incident query
+  #    match nothing so the evidence gate aborts cleanly.
+  - name: resolve
+    type: data.set
+    with:
+      queue_name: "{{ inputs.queue_name | default: event.alerts[0].kibana.alert.grouping.QueueName | default: 'MISSING' }}"
+      alert_timestamp: "{{ inputs.alert_timestamp | default: event.alerts[0].kibana.alert.start | default: 'MISSING' }}"
+      service_name: "{{ inputs.service_name | default: 'the consumer service' }}"
+      triggering_rule: "{{ event.rule.name | default: 'manual run' }}"
+
   # 1. Backlog + lag during the incident: did the visible-message count and the age of
   #    the oldest message climb? That pair is the signature of the queue backing up.
+  #    REQUIRED evidence: a query failure fails the run.
   - name: backlog_incident
     type: elasticsearch.esql.query
     with:
       query: |
         FROM {{ consts.sqs_metrics_index }}
-        | WHERE attributes.QueueName == "{{ inputs.queue_name }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | WHERE attributes.QueueName == "{{ steps.resolve.output.queue_name }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            peak_visible    = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`),
-            avg_visible     = AVG(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`),
-            peak_oldest_age = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateAgeOfOldestMessage`),
-            peak_in_flight  = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesNotVisible`)
+            peak_visible    = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`)    WHERE attributes.stat == "Maximum",
+            avg_visible     = AVG(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`)    WHERE attributes.stat == "Average",
+            peak_oldest_age = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateAgeOfOldestMessage`)         WHERE attributes.stat == "Maximum",
+            peak_in_flight  = MAX(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesNotVisible`) WHERE attributes.stat == "Maximum"
       format: json
-    on-failure:
-      continue: true
 
   # 2. Baseline backlog BEFORE the incident — the comparison denominator.
   - name: backlog_baseline
@@ -75,13 +95,11 @@ steps:
     with:
       query: |
         FROM {{ consts.sqs_metrics_index }}
-        | WHERE attributes.QueueName == "{{ inputs.queue_name }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.baseline_lookend }}
-        | STATS baseline_visible = AVG(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`)
+        | WHERE attributes.QueueName == "{{ steps.resolve.output.queue_name }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.baseline_lookend }}
+        | STATS baseline_visible = AVG(`metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible`) WHERE attributes.stat == "Average"
       format: json
-    on-failure:
-      continue: true
 
   # 3. Throughput balance — sent vs deleted vs received. If sent outpaces deleted, the
   #    producer is arriving faster than the consumer drains; if deleted ~ 0 while sent
@@ -91,108 +109,142 @@ steps:
     with:
       query: |
         FROM {{ consts.sqs_metrics_index }}
-        | WHERE attributes.QueueName == "{{ inputs.queue_name }}"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
+        | WHERE attributes.QueueName == "{{ steps.resolve.output.queue_name }}"
+          AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+          AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
         | STATS
-            sent     = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesSent`),
-            deleted  = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesDeleted`),
-            received = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesReceived`),
-            empty_receives = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfEmptyReceives`)
+            sent     = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesSent`)     WHERE attributes.stat == "Sum",
+            deleted  = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesDeleted`)  WHERE attributes.stat == "Sum",
+            received = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfMessagesReceived`) WHERE attributes.stat == "Sum",
+            empty_receives = SUM(`metrics.amazonaws.com/AWS/SQS/NumberOfEmptyReceives`) WHERE attributes.stat == "Sum"
       format: json
-    on-failure:
-      continue: true
 
-  # 4. Classify the queue failure mode from backlog growth + throughput balance.
-  - name: classify_queue_pattern
-    type: ai.classify
-    with:
-      input: |
-        QueueName: {{ inputs.queue_name }}
-        Backlog during incident: {{ steps.backlog_incident.output | json }}
-        Baseline backlog:        {{ steps.backlog_baseline.output | json }}
-        Throughput balance:      {{ steps.throughput_balance.output | json }}
-      categories:
-        - consumer_lag
-        - consumer_stalled
-        - producer_spike
-        - healthy
-      instructions: |
-        Classify why the SQS queue backlog is behaving as it is:
-          - consumer_lag: peak_visible and peak_oldest_age climb well above baseline,
-            and `deleted` is non-zero but LOWER than `sent` — the consumer is draining
-            but can't keep up with the arrival rate.
-          - consumer_stalled: backlog and oldest-age climb sharply while `deleted` is
-            ~0 (and `empty_receives` may be ~0) — the consumer has stopped draining.
-          - producer_spike: `sent` is sharply elevated vs baseline and far exceeds
-            `deleted` — an arrival-rate surge is the dominant driver.
-          - healthy: peak_visible stays near baseline and oldest-age is low.
-        Pick the single best category. If signals are ambiguous, prefer the most
-        specific that fits (consumer_stalled over consumer_lag when deleted ~ 0).
-      includeRationale: true
+  # 4. Evidence gate — deterministic, BEFORE any AI step. Zero datapoints for the
+  #    resolved queue (wrong/missing name, data not yet ingested, degenerate alert
+  #    group) → refuse to diagnose instead of classifying a row of nulls.
+  - name: evidence_gate
+    type: if
+    condition: "steps.backlog_incident.output.documents_found > 0"
+    steps:
+      # 5. Classify the queue failure mode from backlog growth + throughput balance.
+      - name: classify_queue_pattern
+        type: ai.classify
+        with:
+          input: |
+            QueueName: {{ steps.resolve.output.queue_name }}
+            Backlog during incident: {{ steps.backlog_incident.output | json }}
+            Baseline backlog:        {{ steps.backlog_baseline.output | json }}
+            Throughput balance:      {{ steps.throughput_balance.output | json }}
+          categories:
+            - consumer_lag
+            - consumer_stalled
+            - producer_spike
+            - healthy
+          instructions: |
+            Classify why the SQS queue backlog is behaving as it is:
+              - consumer_lag: peak_visible and peak_oldest_age climb well above baseline,
+                and `deleted` is non-zero but LOWER than `sent` — the consumer is draining
+                but can't keep up with the arrival rate.
+              - consumer_stalled: backlog and oldest-age climb sharply while `deleted` is
+                ~0 (and `empty_receives` may be ~0) — the consumer has stopped draining.
+              - producer_spike: `sent` is sharply elevated vs baseline and far exceeds
+                `deleted` — an arrival-rate surge is the dominant driver.
+              - healthy: peak_visible stays near baseline and oldest-age is low.
+            Pick the single best category. If signals are ambiguous, prefer the most
+            specific that fits (consumer_stalled over consumer_lag when deleted ~ 0).
+            If the baseline returned no rows or nulls, note the comparison is unavailable —
+            do not treat a missing baseline as a zero baseline.
+          includeRationale: true
 
-  # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
-  - name: slo_context
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .slo-observability.summary-*
-        | WHERE slo.instanceId LIKE "*{{ inputs.queue_name }}*"
-        | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
-      format: json
-    on-failure:
-      continue: true
+      # Optional calibration anchors (graceful if SLOs/alerts aren't deployed).
+      - name: slo_context
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .slo-observability.summary-*
+            | WHERE slo.instanceId LIKE "*{{ steps.resolve.output.queue_name }}*"
+            | STATS sliValue = MAX(sliValue), errorBudgetConsumed = MAX(errorBudgetConsumed), status = VALUES(status) BY slo.name
+          format: json
+        on-failure:
+          continue: true
 
-  - name: active_alerts
-    type: elasticsearch.esql.query
-    with:
-      query: |
-        FROM .alerts-*
-        | WHERE kibana.alert.instance.id LIKE "*{{ inputs.queue_name }}*"
-          AND @timestamp >= TO_DATETIME("{{ inputs.alert_timestamp }}") - {{ consts.incident_lookback }}
-          AND @timestamp <= TO_DATETIME("{{ inputs.alert_timestamp }}") + 5 minutes
-        | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
-        | SORT kibana.alert.start DESC
-        | LIMIT 20
-      format: json
-    on-failure:
-      continue: true
+      - name: active_alerts
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM .alerts-*
+            | WHERE kibana.alert.instance.id LIKE "*{{ steps.resolve.output.queue_name }}*"
+              AND @timestamp >= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") - {{ consts.incident_lookback }}
+              AND @timestamp <= TO_DATETIME("{{ steps.resolve.output.alert_timestamp }}") + 5 minutes
+            | KEEP kibana.alert.rule.name, kibana.alert.status, kibana.alert.reason, kibana.alert.start
+            | SORT kibana.alert.start DESC
+            | LIMIT 20
+          format: json
+        on-failure:
+          continue: true
 
-  - name: synthesize_findings
-    type: ai.summarize
-    with:
-      input: |
-        ## SQS incident investigation for {{ inputs.queue_name }}
-        Alert timestamp: {{ inputs.alert_timestamp }}
-        Consumer service: {{ inputs.service_name }}
+      - name: synthesize_findings
+        type: ai.summarize
+        with:
+          input: |
+            ## SQS incident investigation for {{ steps.resolve.output.queue_name }}
+            Alert timestamp: {{ steps.resolve.output.alert_timestamp }}
+            Triggered by: {{ steps.resolve.output.triggering_rule }}
+            Consumer service: {{ steps.resolve.output.service_name }}
 
-        Classification: {{ steps.classify_queue_pattern.output.category }}
-        Rationale: {{ steps.classify_queue_pattern.output.rationale }}
+            Classification: {{ steps.classify_queue_pattern.output.category }}
+            Rationale: {{ steps.classify_queue_pattern.output.rationale }}
 
-        Backlog (incident): {{ steps.backlog_incident.output | json }}
-        Backlog (baseline): {{ steps.backlog_baseline.output | json }}
-        Throughput:         {{ steps.throughput_balance.output | json }}
-        SLO status:    {{ steps.slo_context.output | json }}
-        Active alerts: {{ steps.active_alerts.output | json }}
-      instructions: |
-        You are an SRE assistant synthesising an AWS SQS incident investigation.
-        Produce a structured root-cause summary in EXACTLY these sections:
-        ROOT CAUSE HYPOTHESIS — one sentence naming the most likely cause.
-        EVIDENCE — the specific values: peak vs baseline visible messages, oldest-message
-          age, and the sent-vs-deleted balance.
-        SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
-          materially consumed), or an alert is active for this resource, ANCHOR severity
-          and root cause on that calibrated signal and name the alert/SLO + its reason
-          (the shipped thresholds encode what is "bad" for this resource, which the raw
-          magnitude alone cannot establish). If no SLO/alert context is present or empty,
-          state the assessment rests on raw metrics alone with no SLO/alert corroboration
-          — do NOT invent one.
-        CAUSAL CHAIN — producers enqueue faster than {{ inputs.service_name }} drains →
-          backlog (visible messages) grows → oldest-message age rises → downstream
-          processing is delayed (adjust to the evidence).
-        RECOMMENDED NEXT STEPS — e.g. scale out {{ inputs.service_name }} consumer
-          concurrency / batch size to drain the backlog; shed or throttle producer load
-          until the queue recovers; check for a stalled or crash-looping consumer.
-        DOWNSTREAM IMPACT — what is delayed and the user-facing symptom.
-        CONFIDENCE NOTE — only if the classification was ambiguous.
-      maxLength: 1500
+            Backlog (incident): {{ steps.backlog_incident.output | json }}
+            Backlog (baseline): {{ steps.backlog_baseline.output | json }}
+            Throughput:         {{ steps.throughput_balance.output | json }}
+            SLO status:    {{ steps.slo_context.output | json }}
+            Active alerts: {{ steps.active_alerts.output | json }}
+          instructions: |
+            You are an SRE assistant synthesising an AWS SQS incident investigation.
+            Produce a structured root-cause summary in EXACTLY these sections:
+            ROOT CAUSE HYPOTHESIS — one sentence naming the most likely cause.
+            EVIDENCE — the specific values: peak vs baseline visible messages, oldest-message
+              age, and the sent-vs-deleted balance.
+            SEVERITY & CALIBRATION — if an SLO is VIOLATED/DEGRADING (or its error budget is
+              materially consumed), or an alert is active for this resource, ANCHOR severity
+              and root cause on that calibrated signal and name the alert/SLO + its reason
+              (the shipped thresholds encode what is "bad" for this resource, which the raw
+              magnitude alone cannot establish). If no SLO/alert context is present or empty,
+              state the assessment rests on raw metrics alone with no SLO/alert corroboration
+              — do NOT invent one.
+            CAUSAL CHAIN — producers enqueue faster than the consumer drains →
+              backlog (visible messages) grows → oldest-message age rises → downstream
+              processing is delayed (adjust to the evidence).
+            RECOMMENDED NEXT STEPS — e.g. scale out consumer concurrency / batch size to
+              drain the backlog; shed or throttle producer load until the queue recovers;
+              check for a stalled or crash-looping consumer.
+            DOWNSTREAM IMPACT — what is delayed and the user-facing symptom.
+            CONFIDENCE NOTE — only if the classification was ambiguous.
+          maxLength: 1500
+
+      # Expose the result as the workflow's output for callers / composing workflows.
+      - name: output_result
+        type: workflow.output
+        with:
+          status: "investigated"
+          resource: "{{ steps.resolve.output.queue_name }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          classification: "{{ steps.classify_queue_pattern.output.category }}"
+          rationale: "{{ steps.classify_queue_pattern.output.rationale }}"
+          summary: "{{ steps.synthesize_findings.output.content }}"
+
+    else:
+      - name: output_insufficient_evidence
+        type: workflow.output
+        with:
+          status: "insufficient_evidence"
+          resource: "{{ steps.resolve.output.queue_name }}"
+          triggered_by: "{{ steps.resolve.output.triggering_rule }}"
+          summary: >-
+            No SQS datapoints found for "{{ steps.resolve.output.queue_name }}" in the
+            incident window around {{ steps.resolve.output.alert_timestamp }}. Either the
+            queue name could not be resolved (manual input missing, or the triggering
+            alert's group carries no QueueName), the metrics have not been ingested yet,
+            or the name does not match this cluster's data. Refusing to produce a
+            diagnosis without evidence.


### PR DESCRIPTION
## Summary

Adds four observability root-cause-analysis templates for the AWS OTel (EDOT awscloudwatch) integrations currently in tech preview / heading to GA:

- `aws-alb-5xx-investigation-otel` — ALB 5xx surge (target vs ELB 5xx vs latency)
- `aws-lambda-errors-investigation-otel` — Lambda error spike (errors vs throttles vs duration)
- `aws-rds-connection-exhaustion-investigation-otel` — RDS connection exhaustion vs other DB bottlenecks + ALB cascade
- `aws-sqs-consumer-lag-investigation-otel` — SQS backlog (consumer lag vs stalled vs producer spike)

Each template:
- `solutions: [observability]`, `categories: [root-cause-analysis, monitoring]`, `availability: \">=9.5.0\"`
- Dual triggers: `alert` + `manual` (manual inputs for testing without an alert)
- Uses `elasticsearch.esql.query` + `ai.classify` + `ai.summarize` against default EDOT index patterns (`metrics-aws.*.otel-*`)
- No `install.form` — no connectors; index patterns stay in `consts` as EDOT defaults

Source: developed/proven against the Forge AWS FIS plane for the AWS OTel content workstream. Confirmed with @talboren that library PRs are welcome; CI validation is still incomplete so please help validate step types / runtime once reviewed.

## Validation

`npm run build:catalog` (local, with env overrides):

```
> @elastic/workflows-library@0.0.0 build:catalog
> node scripts/build-catalog.mjs

[build-catalog] Using KIBANA_MAIN_VERSION override: 9.6.0
[build-catalog] Using KIBANA_NAMED_MINORS override: [9.5, 9.6]
[build-catalog] Loaded 22 template(s)
[build-catalog] Resolved main → Kibana 9.6.0
[build-catalog]   → v1/9.5/  (kibana 9.5.0, 22 templates)
[build-catalog]   → v1/9.6/  (kibana 9.6.0, 22 templates)
[build-catalog]   → v1/main/  (kibana 9.6.0, 22 templates)
[build-catalog]   → v1/templates/  (22 version-keyed YAML bodies)
[build-catalog] Done.
```

## Test plan

- [ ] Catalog build green in CI (generator only today)
- [ ] Install each template in a 9.5+ Kibana with Template library enabled
- [ ] Manual run with sample inputs against a cluster that has `metrics-aws.*.otel-*` data (or confirm graceful `on-failure: continue` when empty)
- [ ] Confirm `ai.classify` / `ai.summarize` step types resolve on the target stack
- [ ] Spot-check alert trigger wiring (inputs expected from alert action context)

cc @talboren — as discussed, please help with validation since library CI validation isn't landed yet.

Made with [Cursor](https://cursor.com)