### PR TITLE
Add Google Threat Intelligence workflows

### DIFF
--- a/examples/integrations/google-threat-intelligence/README.md
+++ b/examples/integrations/google-threat-intelligence/README.md
@@ -1,0 +1,336 @@
+# Integrations > Google Threat Intelligence
+
+Google Threat Intelligence enrichment workflows for Elastic Security.
+
+## Workflows (12)
+
+| Workflow | Description |
+|----------|-------------|
+| [GTI MITRE ATT&CK Techniques](./gti-mitre-attack-techniques.yaml) | Retrieve the MITRE ATT&CK tactics and techniques GTI observed for a file hash, grouped by sandbox. Indexes the full response and summarises it on the triggering alert. |
+| [GTI File Sandbox Behaviour](./gti-file-sandbox-behaviour.yaml) | Retrieve GTI sandbox detonation reports for a file hash, paging until GTI has no more to give. Indexes every report as its own document and summarises the whole fetched batch on the triggering alert, one heading per report. |
+| [GTI IP Address Report](./gti-ip-address-report.yaml) | Retrieve the GTI reputation and detection report for an IP address (verdict, threat score, last analysis stats, network ownership, geolocation, tags). Indexes the full response and summarises it on the triggering alert. No pagination, same shape as MITRE ATT&CK Techniques. |
+| [GTI IP Address Relationships](./gti-ip-address-relationships.yaml) | Retrieve objects related to an IP address by relationship type (e.g. communicating files, historical resolutions, hosted URLs). Indexes every related object as its own document and summarises the fetched page on the triggering alert. Manual only - no detection-rule trigger. |
+| [GTI Domain Report](./gti-domain-report.yaml) | Retrieve the GTI reputation and detection report for a domain name (verdict, threat score, last analysis stats, registrar/WHOIS, categorisation, popularity ranks, tags). Indexes the full response and summarises it on the triggering alert. No pagination, same shape as IP Address Report. |
+| [GTI Domain Relationships](./gti-domain-relationships.yaml) | Retrieve objects related to a domain name by relationship type (e.g. subdomains, historical resolutions, communicating files - 30 relationship values, the largest enum after File Hash Relationships). Indexes every related object as its own document and summarises the fetched batch on the triggering alert. Manual only. |
+| [GTI File Hash Report](./gti-file-hash-report.yaml) | Retrieve the GTI reputation and detection report for a file by hash (verdict, threat score, popular threat classification, file type metadata, signature info, tags). A different action from File Sandbox Behaviour (sandbox detonation) and MITRE ATT&CK Techniques (technique tree) - this one is the reputation report, the file-hash equivalent of IP Address Report / Domain Report. |
+| [GTI File Hash Relationships](./gti-file-hash-relationships.yaml) | Retrieve objects related to a file by relationship type (e.g. contacted domains, dropped files, sandbox behaviours - 49 relationship values, by far the largest of the four GTI relationship actions). Indexes every related object as its own document and summarises the fetched batch on the triggering alert. Manual only. |
+| [GTI URL Report](./gti-url-report.yaml) | Retrieve the GTI reputation and detection report for a URL (verdict, threat score, last analysis stats, final resolved destination, HTTP response metadata, categorisation, tags). Indexes the full response and summarises it on the triggering alert. No pagination, same shape as the other three report workflows. |
+| [GTI URL Relationships](./gti-url-relationships.yaml) | Retrieve objects related to a URL by relationship type (e.g. redirects, contacted domains, downloaded files - 31 relationship values). Indexes every related object as its own document and summarises the fetched batch on the triggering alert. Manual only. |
+| [GTI URL Scan (Public)](./gti-url-scan-public.yaml) | Submit a URL to GTI for public analysis, poll until the scan completes, then retrieve and index the full report. Unlike the report/relationship workflows above, this one submits new content to GTI rather than reading an already-computed verdict, so it chains three actions (submit, poll, retrieve) in one execution instead of one lookup. Public sibling of GTI URL Scan (Private) below - same pipeline, but a fresh scan's multi-engine stats are populated immediately (unlike private) and the note links to GTI's real public GUI page. |
+| [GTI URL Scan (Private)](./gti-url-scan-private.yaml) | Submit a URL to GTI for private analysis (not shared with the wider GTI community), poll until the scan completes, then retrieve and index the full report. Unlike every other workflow above, this one submits new content to GTI rather than reading an already-computed verdict, so it chains three actions (submit, poll, retrieve) in one execution instead of one lookup. Summarises the result on the triggering alert. |
+
+## Prerequisites
+
+| Requirement | Detail |
+|---|---|
+| Elastic Stack | 9.6.0 or later |
+| Elastic license | Enterprise |
+| GTI subscription | Enterprise. The connector's Test action fails with a clear message on a lower tier, because `gti_assessment` is absent from responses. |
+| Connector | A configured **Google Threat Intelligence** connector (`.google_threat_intelligence`). Set `consts.gti_connector_id` in each workflow to its id. **As of this writing the connector itself ships only on the `google_threat_intelligence-connector` Kibana branch, not on `main` and not in any released build.** These workflows will fail at the connector-resolution step on a stock Kibana instance until that connector PR merges. Do not treat "Kibana 9.6.0" alone as the compatibility bar; the real bar is "Kibana 9.6.0 with that connector merged," which is why this line calls it out separately from the Elastic Stack row above. |
+
+## Kibana privileges
+
+The user or API key running these workflows needs:
+
+- **Analytics > Workflows**: `All` to create and run, `Read` to view
+- **Security > Alerts**: read on the alert indices to fetch the observable, and write for the tag step
+- **Security > Notes**: `notes_read` and `notes_write`. Both are used: read to find a previous note so a re-run replaces it rather than stacking a second copy, write to save it.
+- **Index privileges**: `write` on `gti-soar-*`
+
+## Setup
+
+### 1. Data view for the note's Discover link (automatic, no action needed)
+
+Each workflow finds or creates its own data view, one per destination index (id and title both equal
+`consts.index`, e.g. `gti-soar-mitre-attack`), the first time it runs with an alert to annotate. A
+standalone run (no alert) never touches this, since there is no note to link from.
+
+Creation can fail on a role that has everything else this workflow needs but not
+`indexPatterns:manage`, a normal and expected privilege split, not a bug. When that happens the note
+falls back to printing the index and document id as plain text instead of linking with a broken or
+missing data view segment. Either way the workflow keeps working; only the note's presentation changes.
+
+If you would rather pre-create the data view yourself (e.g. to control its name, or because the role
+running the workflow will never have `indexPatterns:manage`), do it once per space per workflow:
+
+```
+POST kbn:/api/data_views/data_view
+{
+  "data_view": {
+    "id": "gti-soar-mitre-attack",
+    "title": "gti-soar-mitre-attack",
+    "name": "gti-soar-mitre-attack",
+    "timeFieldName": "@timestamp",
+    "allowNoIndex": true
+  }
+}
+```
+
+### 2. Index template (automatic, no action needed)
+
+Every workflow self-provisions its own index template as its own first step (`bootstrap_index_template`,
+`type: elasticsearch.request`, `PUT _index_template/<its own index name>`), every run. There is nothing to
+run by hand before the first real execution - this replaced an earlier design that required an operator to
+apply a shared template manually, which this project's own dev instance proved unreliable: indices created
+before that manual step was run (or before the template existed at all) silently never picked up its
+settings, invisible until their raw `_settings` were checked directly.
+
+Each workflow's template sets, on its own index only:
+
+```json
+{
+  "index.mapping.total_fields.limit": 2000,
+  "index.mapping.total_fields.ignore_dynamic_beyond_limit": true,
+  "index.mapping.ignore_malformed": true
+}
+```
+
+This is not a theoretical safety valve:
+
+- `getIpReport`'s response for a heavily-annotated address (`rdap`, `last_https_certificate`,
+  `gti_assessment.gti_description_cards`) pushed `gti-soar-ip-report` past the default 1000-field limit
+  and failed the index step until `total_fields.limit`/`ignore_dynamic_beyond_limit` were applied.
+- `getDomainReport` and `getUrlReport` both carry vendor-name-keyed maps (`categories`,
+  `popularity_ranks`) - every new vendor GTI aggregates adds a new field path under the raw `gti.*` dump.
+- `gti-soar-ip-relationship` shares one index across GTI's 22 relationship object types, and genuinely
+  collides on the same field path with an incompatible value type across some of them (confirmed live:
+  `attributes.threat_severity.version` is a number on file-family objects, the string `"U3"` on url
+  objects). `ignore_malformed` absorbs this by dropping just the losing field into `_ignored` for that one
+  document rather than rejecting it outright - a deliberate trade-off over marking the whole `gti` field
+  `enabled: false`, which would guarantee safety against a harder (object-vs-scalar) collision not yet
+  observed in 18 of the 22 relationship types, at the cost of losing search/aggregation on every field
+  under `gti` for every item, colliding or not.
+
+**This can only protect an index that does not exist yet at the moment a workflow first runs against it**
+- an index template only takes effect at index-creation time, never retroactively. If you already have a
+`gti-soar-*` index from before this existed (check with `GET <index>/_settings`),
+`total_fields.limit`/`ignore_dynamic_beyond_limit` can be added to it directly (`PUT <index>/_settings`),
+but `ignore_malformed` needs `?reopen=true` on that same settings call (a brief close/reopen), and any
+mapping override needs the index recreated (or a proper reindex-and-repoint if it already holds real data
+you can't lose).
+
+Do not rename these indices to `logs-gti-*`. That pattern is claimed by the built-in `logs` template, which creates data streams only, so a plain index write is refused outright.
+
+## Running the workflows
+
+Each workflow supports three paths, and the body is identical across them - **except the four
+relationship workflows (IP Address, Domain, File Hash, URL), which support only the last two.** Each
+declares `triggers: [manual]` with no `alert` trigger at all, since a relationship response can be far
+larger than any other action's, and there is no relationship worth choosing automatically on every alert.
+
+| Path | How it starts | What it writes | Supported by |
+|---|---|---|---|
+| Detection rule | Rule action using the `.workflows` connector | Index, alert note, alert tag | MITRE ATT&CK Techniques, File Sandbox Behaviour, IP Address Report, Domain Report, File Hash Report, URL Report |
+| Manual against an alert | **Run workflow** from the alert table or flyout, or supply `alert_index` and `alert_id` | Index, alert note, alert tag | All ten |
+| Manual, standalone | Workflows app, supplying the observable directly | Index only | All ten |
+
+Turn on **Run per alert** on the `.workflows` connector when using a rule action. In summary mode the alert batch arrives together and the workflow processes only the observables of the alerts in that batch.
+
+### Choosing which alert fields are read
+
+Each workflow reads observables from the alert fields listed in `consts.observable_fields`, resolved by dotted path at run time. We have provided some default example fields - please update them according to your own needs. Add or remove entries there and no step needs editing:
+
+```yaml
+consts:
+  observable_fields: ["file.hash.sha256", "process.hash.sha256", "dll.hash.sha256"]
+```
+
+Values that repeat across fields are enriched once. On the three file-hash workflows (MITRE ATT&CK
+Techniques, File Sandbox Behaviour, File Hash Report), a value that is not a valid hash length (32/40/64
+hex characters) is skipped, because the connector validates `fileHash` against a SHA-256, SHA-1 or MD5
+pattern before the request is made. On the two IP workflows, `observable_fields` defaults to
+`["source.ip", "destination.ip", "host.ip", "client.ip", "server.ip"]` - no length/format guard is applied
+there, since these are ECS `ip`-typed fields, already validated by the mapping before they ever reach an
+alert. Domain Report defaults to `["url.domain", "dns.question.name", "destination.domain",
+"source.domain"]`; URL Report and both URL Scan workflows (public and private) all default to
+`["url.full", "url.original"]`.
+
+### Pagination (GTI File Sandbox Behaviour and all four relationship workflows)
+
+`getFileBehaviours` pages via `limit`/`cursor`, unlike the MITRE ATT&CK action. GTI File Sandbox Behaviour
+pages with a native `while` step until GTI's own cursor comes back blank — there is no fixed page or item
+ceiling by design. Each page's reports are indexed immediately and then discarded, rather than accumulated
+for a single pass at the end, so memory stays bounded to one page (40 reports) regardless of how many total
+reports a hash has. A large iteration count (250 pages, set on the `paginate` step's `max-iterations`) exists purely as a
+backstop against a vendor-side cursor bug that should never fire in practice; if it ever does, that's
+surfaced as an "unexpectedly large result set" callout in the note rather than failing silently. An
+optional `limit` input overrides the per-page fetch size (defaults to 40, GTI's own maximum for this
+endpoint) - it does not cap the total number of reports collected. On a standalone run only, an optional
+`cursor` input lets you resume from the cursor surfaced in that callout if the backstop is ever hit.
+
+`getIpRelationship`/`getDomainRelationship`/`getFileRelationship`/`getUrlRelationship` all page via
+`limit`/`cursor` the identical way, to full exhaustion, using the same `while` loop and safety backstop
+File Sandbox Behaviour uses - **not** one page per run. A relationship collection can be far larger than
+any single hash's sandbox history (`communicating_files` on a busy IP has been observed reporting a
+`meta.count` in the millions, and real runs have collected far more items than that count even reported),
+so the safety backstop matters more here than anywhere else in this project, but the design is the same:
+page until GTI's cursor goes blank, index each page immediately, write exactly one note per
+observable+relationship pair covering every page fetched - never one page per run and never one note per
+page. `limit` on these four workflows works the same way as on File Sandbox Behaviour above - it only
+overrides the per-page fetch size, not the total items collected. `cursor` is only meaningful on a
+standalone run that previously hit the safety backstop, to resume from where it left off.
+
+### Polling (GTI URL Scan (Public) and GTI URL Scan (Private))
+
+Unlike every other workflow above, these two submit new content to GTI (`scanUrl`/`scanPrivateUrl`) rather
+than reading an already-computed verdict, then poll (`getAnalysis`/`getPrivateAnalysis`) until the scan
+finishes before retrieving the report (`getUrlScanReport`/`getPrivateUrlReport`) - three actions chained in
+one execution, not one lookup. The poll loop checks status immediately each iteration and only sleeps 10
+seconds if the scan is still `queued`/`in-progress`, up to 60 iterations (a 10-minute ceiling), modeled on
+Censys's own shipped `Rescan` workflow's identical submit-poll-refetch shape. If GTI hasn't finished by the
+time the ceiling is hit, the run is marked `partial` rather than `failed` - the scan was genuinely submitted
+and is still processing on GTI's side, so the note and indexed record carry the analysis id for the analyst
+to check back on later, instead of reporting an error that didn't happen. All six of `scanPrivateUrl`'s
+optional parameters (user agent, sandboxes, retention period, storage region, interaction sandbox,
+interaction timeout) are exposed as workflow inputs on the private workflow only; any left blank are omitted
+from the request entirely so GTI applies its own default rather than the workflow sending an empty override.
+`scanUrl` (the public workflow) takes no optional parameters at all - just the URL.
+
+One real behavioral difference between the two, confirmed live rather than assumed: a public scan's
+multi-engine analysis stats (`last_analysis_stats`, `reputation`, `total_votes`) are populated immediately on
+a fresh, never-before-seen URL, while a private scan's are not (private analysis is isolated from GTI's
+public multi-engine pipeline). Both workflows guard their note's Detection/Reputation/Community-votes
+sections on whether this data actually came back, rather than defaulting to `0` and rendering a false "0
+detections" for a URL nothing has actually analyzed yet.
+
+## Destination indices
+
+One index per action, so responses of different shapes are never mixed.
+
+| Workflow | Index |
+|---|---|
+| GTI MITRE ATT&CK Techniques | `gti-soar-mitre-attack` |
+| GTI File Sandbox Behaviour | `gti-soar-file-behaviour` |
+| GTI IP Address Report | `gti-soar-ip-report` |
+| GTI IP Address Relationships | `gti-soar-ip-relationship` |
+| GTI Domain Report | `gti-soar-domain-report` |
+| GTI Domain Relationships | `gti-soar-domain-relationship` |
+| GTI File Hash Report | `gti-soar-file-report` |
+| GTI File Hash Relationships | `gti-soar-file-relationship` |
+| GTI URL Report | `gti-soar-url-report` |
+| GTI URL Relationships | `gti-soar-url-relationship` |
+| GTI URL Scan (Public) | `gti-soar-url-scan-public` |
+| GTI URL Scan (Private) | `gti-soar-url-scan-private` |
+
+**GTI MITRE ATT&CK Techniques**, **GTI IP Address Report**, **GTI Domain Report**, **GTI File Hash
+Report**, **GTI URL Report**, **GTI URL Scan (Public)**, and **GTI URL Scan (Private)** each write one document per
+observable, id `sha256("<alert id or 'manual'>-<observable>")`. **GTI URL Scan (Public)** and **GTI URL Scan
+(Private)** are each their own separate index, distinct from GTI URL Report and from each other, even though
+all three retrieve the same underlying report object shape for a URL - a scan document represents that
+workflow's own submission (it carries the analysis id), and, unlike every other workflow's id scheme,
+re-running either scan workflow against the same URL triggers a genuinely new GTI submission each time
+rather than repeating a free, idempotent lookup; the id still refreshes the same document in place so
+re-runs don't pile up copies.
+**GTI File Sandbox Behaviour** writes one document *per sandbox report* returned for that hash (a hash with
+5 sandbox runs gets 5 documents), id `sha256("<alert id or 'manual'>-<observable>-<report id>")` — the same
+scheme with the report's own id folded in, so a document's identity survives a re-run regardless of which
+page happened to return it.
+**All four relationship workflows** (IP Address, Domain, File Hash, URL) write one document *per related
+object* returned for that observable+relationship pair, id
+`sha256("<alert id or 'manual'>-<observable>-<relationship>-<related object id>")` — the relationship
+name is folded in alongside the item's own id, so the same observable enriched for two different
+relationships (e.g. `resolutions` and `communicating_files`) never collides on id even if a vendor item id
+were ever reused across object types.
+
+Either way, ids are hashed rather than concatenated raw because Elasticsearch rejects any `_id` over 512
+bytes, and while a file hash observable is always short, this id scheme is meant to carry over unchanged to
+workflows whose observable is a URL, which can comfortably exceed that limit on its own. The hash keeps the
+id a fixed 64 characters regardless of observable length while staying fully deterministic, so re-running
+against the same alert refreshes the same document(s) rather than accumulating near-duplicates. The
+readable identity is not lost, it just moves into the document body: every document also carries
+`kibana.alert.uuid`, the alert index, `rule.id`, `rule.name`, `observable`, `trigger_mode` and
+`workflow.execution_id`, which is what links it back to the alert and back to the run that produced it.
+
+## What happens when a fetch fails
+
+Every workflow handles this identically, on every trigger path: a failed fetch (after the standard 2
+retries) is never silent on any surface.
+
+- **Console**: always logs a line starting `STATUS: succeeded` / `STATUS: partial` (paginated workflows,
+  when the safety backstop is hit; GTI URL Scan and GTI URL Scan (Private), when the poll loop's own
+  backstop is hit before GTI reports the scan complete) / `STATUS: failed`, regardless of path or workflow.
+- **Index**: a `fetch_failure` document is written for any non-`succeeded` outcome - `event.outcome:
+  failure`, ECS `error.message`/`error.type` (left blank, not fabricated, when the underlying event genuinely
+  isn't an API error - e.g. the pagination safety backstop firing, or either URL Scan workflow's own poll
+  timeout), plus the same correlation block every document already carries. Same deterministic id scheme as
+  every other document, so a re-run refreshes it in place rather than piling up copies, and it never
+  overwrites the last actually-successful document for that observable.
+- **Alert note** (paths 1/2 only - a standalone run has no alert to annotate): on `failed`, the note is
+  **replaced** with a short status message pointing at the indexed failure record - including replacing a
+  prior *successful* note, so a failed re-run is never mistaken for "nothing changed since last time." A
+  paginated workflow's `partial` result still shows the real data collected, with an "Incomplete" or "safety
+  limit reached" callout. Either URL Scan workflow's own `partial` is different in kind, not just in wording -
+  its scan genuinely has no report data yet (GTI is still processing it), so the note instead surfaces the
+  analysis id and says so plainly, pointing the analyst at re-running later or polling GTI directly.
+- **Tag**: never applied on `failed` (nothing was actually enriched). Still applied on `partial` - for a
+  paginated workflow, because real data was retrieved even though the run didn't finish; for either URL Scan
+  workflow, because a scan was genuinely submitted and is in flight, even though no report exists yet.
+
+## Notes on the alert
+
+One note per observable, regardless of how many documents that observable's run produced. A re-run finds
+its previous note by a marker containing the observable and replaces it, so notes do not stack. The note is
+machine-owned and says so: anything typed into it by hand is overwritten on the next run, so analyst
+commentary belongs in a separate note.
+
+The File Sandbox Behaviour and IP Address Relationships notes each render one heading section per fetched
+item (sandbox name/related-object type+id, verdict or reputation, tags, and a link to the exact indexed
+document for that item) — the same heading-plus-bullet-list shape the MITRE ATT&CK and IP Address Report
+workflows' own notes use, not a markdown table. That's a deliberate, tested choice, not a style preference:
+the alert note list renders through EUI's default markdown plugins, which do not include `remark-gfm`, so
+pipe-table syntax (`| a | b |`) never renders as an actual table there — it shows as literal, broken text.
+
+Every note surfaces more than the bare minimum: GTI IP Address Report's note includes GTI's own
+plain-English verdict rationale, community vote counts, and crowdsourced threat-intel context when present,
+not just verdict/network/geo. Domain Report, File Hash Report, and URL Report follow the same pattern with
+fields specific to each observable type - registrar/WHOIS excerpt/popularity ranks for domains, popular
+threat classification/signature info/file metadata for hashes, final resolved destination/HTTP
+status/redirection chain for URLs - all live-verified against real GTI responses, not guessed field names.
+Domain Report and URL Report also flatten GTI's vendor-name-keyed `categories` map (`alphaMountain.ai`,
+`BitDefender`, `Sophos`, ...) into a plain "vendor: category" string via the `entries` filter, rather than
+indexing it as an object, so a new vendor GTI adds never grows that curated summary block's own field
+count. IP Address Relationships' per-item sections are type-aware, not one generic
+template: `getIpRelationship` covers 22 different relationship values, each returning a differently-shaped
+object, all sharing the same `{id, type, links.self, attributes}` envelope but not the same `attributes`
+fields. **All 22 relationship names are covered** by a dedicated section for the object type they return
+(`resolution`, `file`, `url`, `vote`, `comment`, `collection`, `ssl_cert`, `graph`, `whois`) — nine types in
+total, since several relationship names share a type (e.g. `votes`/`user_votes` both return `vote`;
+`campaigns`/`software_toolkits`/`related_threat_actors`/`vulnerabilities`/`malware_families`/`associations`/
+`collections`/`reports`/`related_reports` all return `collection`, just with a different `collection_type`).
+Coverage for four of those relationship names (`related_threat_actors`, `vulnerabilities`, `campaigns`,
+`software_toolkits`) rests on the vendor's own reference docs rather than a directly-observed populated
+response — every address tried returned zero items for those four specifically. A bare generic fallback
+(`last_analysis_stats`/`reputation`/`tags` if present) still exists, purely as a safety net for any
+relationship GTI adds in the future.
+
+**GTI Domain Relationships, GTI File Hash Relationships, and GTI URL Relationships share this exact
+type-aware note mechanism**, reusing the same nine per-item cases unchanged and adding new ones only
+where the underlying object type genuinely differs:
+- Domain Relationships adds a `domain` case (several of its 30 relationship names - `subdomains`,
+  `ns_records`, `mx_records`, `caa_records`, `cname_records`, `parent`/`immediate_parent`/`siblings`,
+  `soa_records` - return a related *domain* rather than one of the nine types above; confirmed live to
+  carry `last_analysis_stats`, `reputation`, `tags`, `tld`, `registrar`, and `threat_severity`, but never
+  `gti_assessment`, which only appears on GTI Domain Report's own primary lookup).
+- File Hash Relationships adds `ip_address` (same field shape as GTI IP Address Report's own response)
+  and `file_behaviour` (the identical shape GTI File Sandbox Behaviour's own action already returns),
+  reusing `domain` from Domain Relationships too. Its own relationship set is the largest of the four (49
+  values); four names (`analyses`, `attack_techniques`/`related_attack_techniques`, `screenshots`,
+  `submissions`) fall through to the generic fallback, not yet confirmed populated on any hash tried.
+- URL Relationships introduces no new object type at all - its 31 relationship names are fully covered by
+  cases already built across the other three relationship workflows, except `analyses` and `submissions`,
+  which fall through to the generic fallback for the same reason.
+
+There is also no single link that opens every fetched document at once. A pre-filtered Discover `_a`
+app-state URL is technically possible (verified against Kibana's real rison encoder), but it depends on
+Discover's internal state shape rather than a stable, versioned route, and was deliberately not shipped for
+that reason. Each report's own document link instead uses the same stable
+`/app/discover#/doc/<dataViewId>/<index>?id=` route the MITRE ATT&CK workflow's note link already relies
+on.
+
+## Limits
+
+- `xpack.actions.maxResponseContentLength` defaults to 1 MB and the Actions framework rejects larger responses. `getFileMitreAttackTechniques` and `getIpReport` have no limit or cursor parameter, so a file with many sandbox detonations, or an IP with a very large report, returns everything in one response and can approach this bound. `getFileBehaviours` and `getIpRelationship` bound their own per-call response via `limit`, so a single page is *usually* small regardless of how many total items exist — but **`limit` does not always help**: `malware_families`/`related_threat_actors` (`collection`-typed items, deeply nested `aggregations`/`counters`/activity-history data) and `graphs` (items carrying hundreds of `nodes`) can each individually exceed 1 MB, confirmed live even at `limit: 1`. When this happens, `on-failure: retry` then `continue` catches it, the run is marked `fetch_incomplete`, a queryable `fetch_failure` document is written (same `doc_type` every GTI workflow's failure record uses), and the note shows either an "Incomplete" callout (if some earlier pages already succeeded, `run_status: partial`) or a `STATUS: failed` replacement (if the very first page failed) — see "What happens when a fetch fails" below; never a crash or a silently-stale note.
+- Relationship actions are exposed on manual runs only. There is no relationship worth selecting automatically, the responses are the largest GTI returns (`getIpRelationship`'s own `meta.count` has been observed in the millions for a single address+relationship pair, and is not a reliable total besides — real runs have collected far more items than `meta.count` reported), and an automated pivot on every alert would spend API quota on questions nobody asked.
+- `gti-soar-ip-relationship` shares one index across all 22 relationship object types, each with its own independently-shaped `attributes`. Left fully dynamic, a field name reused across object types with an incompatible value shape can fail an otherwise-healthy document (Elasticsearch locks a field's type from the first document it sees), and confirmed live this genuinely happens (`attributes.threat_severity.version`: a number on file-family objects, the string `"U3"` on url objects; several `attributes.exiftool.*` size fields inconsistently string vs number even within one object type). `index.mapping.ignore_malformed: true` on this index's own bootstrap template absorbs every case actually found - the losing document's field drops into `_ignored` rather than the document being rejected. A harder case (a field that's an object on one relationship type and a plain scalar on another) would not be saved by `ignore_malformed` alone, but was checked live across 18 of the 22 relationship types and not found - if a future action's collision turns out to need it, `mappings.properties.gti: { enabled: false }` is the fallback, at the cost of losing search/aggregation on every field under `gti` for every item, not just the colliding one.
+- GTI fields are not ECS aligned and no ingest pipeline is applied, so they do not populate ECS dashboards or feed Indicator Match rules. Each workflow additionally writes exactly one, unconditional alert tag (`gti:mitre-attack`, `gti:file-sandbox`, `gti:ip-report`, `gti:ip-relationship`, `gti:domain-report`, `gti:domain-relationship`, `gti:file-report`, `gti:file-relationship`, `gti:url-report`, `gti:url-relationship`) — indexed and therefore filterable from the alerts table, unlike `gti.*` itself. By design there is no second, verdict-reflecting tag (e.g. a `gti:malicious`) on any GTI workflow, even where the underlying data carries a verdict — kept deliberately simple; the verdict itself is still visible in the note and the indexed document.
+- `getIpReport`'s response can be considerably wider than a file-hash report: a real, heavily-annotated public address indexed to well over 1000 dynamically-mapped fields in testing. Every workflow's own bootstrap step (see "Index template" above) sets a field-count safety margin automatically now, so this is no longer something an operator needs to apply by hand.

--- a/examples/integrations/google-threat-intelligence/gti-domain-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-domain-relationships.yaml
@@ -1,0 +1,757 @@
+# Retrieves objects related to a domain name by relationship type (e.g.
+# subdomains, resolutions, communicating_files - 30 values), paging until
+# GTI has no more to give, and indexes every related object as its own
+# document. Writes one summary note (one section per item) and an alert tag
+# when run against an alert. Manual only, same reasoning as GTI IP Address
+# Relationships.
+version: '1'
+name: GTI Domain Relationships
+description: >-
+  Retrieve objects related to a domain name by relationship type (e.g.
+  subdomains, historical resolutions, communicating files), paging until GTI
+  has no more to give. Indexes every related object as its own document and
+  summarises the whole fetched batch on the triggering alert. Manual only;
+  not attached to a detection rule.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - domain-relationship
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-domain-relationship
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["url.domain", "dns.question.name", "destination.domain", "source.domain"]
+  gti_ui_base: https://www.virustotal.com/gui/domain
+  empty_arr: []
+  page_size: 40
+
+triggers:
+  - type: manual
+    inputs:
+      - name: domain
+        type: string
+        required: false
+        description: >-
+          Domain name, e.g. "example.com". Leave blank when running against
+          an alert, the domain is read from the alert instead.
+      # Safe to require: this workflow has no alert trigger, so there's no automatic
+      # run this could ever block.
+      - name: relationship
+        type: string
+        required: true
+        description: >-
+          Relationship to retrieve, e.g. "subdomains", "resolutions", or
+          "communicating_files". GTI validates this against its own current
+          set for domain objects and returns a 404 for a value it does not
+          recognize; the workflow surfaces that as a skipped domain rather
+          than a failed run. Full current list:
+          https://gtidocs.virustotal.com/reference/domains-object#relationships
+      - name: limit
+        type: number
+        required: false
+        description: >-
+          Page size for each internal GTI fetch while paging (advanced,
+          rarely needed - defaults to 40, GTI's own maximum for this
+          endpoint). This does not cap the total number of items collected:
+          the workflow still pages until GTI reports no more, or the safety
+          backstop (250 pages, see the paginate step) is hit; it only changes
+          how many items are requested per underlying API call.
+      - name: cursor
+        type: string
+        required: false
+        description: >-
+          Continuation cursor from a previous standalone run's
+          pagination.next_cursor (only meaningful together with domain, when
+          a prior run hit the safety backstop below and left more items
+          unfetched). Ignored on every other run - an alert-attached run
+          always pages from the start.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write. Same reasoning and settings as
+  # gti-ip-address-relationships.yaml's bootstrap_index_template step.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_doc_link_base
+    type: data.set
+    with:
+      doc_link_base: |-
+        {%- if variables.data_view_id != blank -%}
+          {%- assign sp = '' -%}
+          {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+          {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.domain != blank -%}
+        {"field":"manual","value":"{{ inputs.domain | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable domain found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the domain input. Nothing to look up.
+
+  - name: enrich_each_domain
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_iter
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+
+      - name: init_pagination
+        type: data.set
+        with:
+          note_sections: "${{ consts.empty_arr }}"
+          page_cursor: "{%- if variables.target_id == blank -%}{{ inputs.cursor }}{%- endif -%}"
+          has_more: true
+          collected: 0
+          any_success: false
+          fetch_incomplete: false
+
+      - name: paginate
+        type: while
+        condition: "${{ variables.has_more == true }}"
+        # Backstop only (GTI's own cursor going blank is the real stop condition), so a
+        # vendor-side cursor bug can't loop forever. `max-iterations` only accepts a literal
+        # number or {limit, on-limit} - not a template - so this can't be pulled from consts.
+        max-iterations: 250
+        steps:
+
+          - name: get_domain_relationship
+            type: google_threat_intelligence.getDomainRelationship
+            connector-id: "{{ consts.gti_connector_id }}"
+            with:
+              domain: "{{ variables.observable }}"
+              relationship: "{{ inputs.relationship }}"
+              limit: "${{ inputs.limit | default: consts.page_size }}"
+              cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              retry:
+                max-attempts: 2
+                delay: 3s
+              continue: true
+
+          - name: collect_page
+            type: if
+            condition: "${{ steps.get_domain_relationship.error == blank }}"
+            steps:
+              # parent and immediate_parent return a single object rather than an array
+              - name: stash_page
+                type: if
+                condition: "${{ steps.get_domain_relationship.output.data.id != blank }}"
+                steps:
+                  - name: stash_single_item
+                    type: data.set
+                    with:
+                      page_items: "${{ consts.empty_arr | push: steps.get_domain_relationship.output.data }}"
+                      page_next_cursor: "{{ steps.get_domain_relationship.output.meta.cursor }}"
+                else:
+                  - name: stash_array_items
+                    type: data.set
+                    with:
+                      page_items: "${{ steps.get_domain_relationship.output.data | default: consts.empty_arr }}"
+                      page_next_cursor: "{{ steps.get_domain_relationship.output.meta.cursor }}"
+
+              - name: index_page_items
+                type: foreach
+                foreach: "${{ variables.page_items }}"
+                steps:
+                  - name: compute_item_doc_id
+                    type: data.set
+                    with:
+                      item_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-' | append: foreach.item.id | sha256 }}"
+
+                  - name: index_relationship_item
+                    type: elasticsearch.index
+                    with:
+                      index: "{{ consts.index }}"
+                      id: "{{ variables.item_doc_id }}"
+                      document:
+                        "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                        event:
+                          kind: enrichment
+                          category: threat
+                          dataset: gti_soar.domain_relationship
+                        observable:
+                          type: domain
+                          field: "{{ variables.field_name }}"
+                          value: "{{ variables.observable }}"
+                        relationship: "{{ inputs.relationship }}"
+                        trigger_mode: "{{ variables.trigger_mode }}"
+                        kibana:
+                          alert:
+                            uuid: "{{ variables.target_id }}"
+                            index: "{{ variables.target_index }}"
+                        rule:
+                          id: "{{ variables.rule_id }}"
+                          name: "{{ variables.rule_name }}"
+                        workflow:
+                          execution_id: "{{ execution.id }}"
+                        summary:
+                          related_object_id: "{{ foreach.item.id }}"
+                          related_object_type: "{{ foreach.item.type }}"
+                          reputation: "${{ foreach.item.attributes.reputation | plus: 0 }}"
+                          tags: "${{ foreach.item.attributes.tags | default: consts.empty_arr }}"
+                        gti: "${{ foreach.item }}"
+                    on-failure:
+                      continue: true
+
+                  # Type-aware per-item section - reuses the nine object-type
+                  # cases from GTI IP Address Relationships unchanged, plus a
+                  # 'domain' case for relationship names that return a
+                  # related domain instead (subdomains, ns/mx/caa/cname/soa
+                  # records, parent/siblings). Any type not covered falls
+                  # through to the generic fields below.
+                  - name: build_item_note_section
+                    type: data.set
+                    with:
+                      item_note_section: |-
+                        {%- assign a = foreach.item.attributes -%}
+                        {%- assign t = foreach.item.type -%}
+                        {%- assign stats = a.last_analysis_stats -%}
+                        {%- assign tags = a.tags | default: consts.empty_arr -%}
+                        ### {{ t }}: {{ foreach.item.id }}
+                        {%- case t %}
+                          {%- when 'domain' %}
+                        {%- if a.threat_severity.threat_severity_level != blank %}
+                        - **Severity:** {{ a.threat_severity.threat_severity_level }}{% if a.threat_severity.level_description != blank %} ({{ a.threat_severity.level_description }}){% endif %}
+                        {%- endif %}
+                        {%- if a.tld != blank or a.registrar != blank %}
+                        - **Domain info:** {% if a.tld != blank %}TLD {{ a.tld }}{% endif %}{% if a.registrar != blank %}{% if a.tld != blank %}, {% endif %}registrar {{ a.registrar }}{% endif %}
+                        {%- endif %}
+                          {%- when 'resolution' %}
+                        {%- if a.host_name != blank %}
+                        - **Host name:** {{ a.host_name }}
+                        {%- endif %}
+                        {%- if a.date != blank %}
+                        - **Resolved:** {{ a.date | date: '%Y-%m-%d' }}{% if a.resolver != blank %} via {{ a.resolver }}{% endif %}
+                        {%- endif %}
+                          {%- when 'file' %}
+                        {%- assign fname = a.meaningful_name | default: a.names[0] -%}
+                        {%- if fname != blank %}
+                        - **Name:** {{ fname }}
+                        {%- endif %}
+                        {%- if a.type_description != blank or a.size != blank %}
+                        - **Type:** {% if a.type_description != blank %}{{ a.type_description }}{% endif %}{% if a.size != blank %}, {{ a.size }} bytes{% endif %}
+                        {%- endif %}
+                        {%- if a.first_submission_date != blank %}
+                        - **First submitted:** {{ a.first_submission_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'url' %}
+                        {%- if a.title != blank %}
+                        - **Title:** {{ a.title }}
+                        {%- endif %}
+                        {%- if a.last_final_url != blank %}
+                        - **Final URL:** {{ a.last_final_url }}
+                        {%- endif %}
+                        {%- if a.threat_names.size > 0 %}
+                        - **Threat names:** {{ a.threat_names | join: ', ' }}
+                        {%- endif %}
+                          {%- when 'vote' %}
+                        - **Verdict:** {{ a.verdict }}{% if a.value != blank %} (value {{ a.value }}){% endif %}
+                        {%- if a.date != blank %}
+                        - **Date:** {{ a.date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'comment' %}
+                        {%- assign comment_line = a.text | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                        - **Comment:** {{ comment_line }}
+                          {%- when 'collection' %}
+                        {%- if a.name != blank %}
+                        - **Name:** {{ a.name }}
+                        {%- endif %}
+                        {%- if a.collection_type != blank %}
+                        - **Type:** {{ a.collection_type }}
+                        {%- endif %}
+                        {%- assign summary_raw = a.executive_summary | default: a.analyst_comment | default: a.description -%}
+                        {%- if summary_raw != blank %}
+                        {%- assign summary_line = summary_raw | strip_html | replace: '\n', ' ' | replace: '  ', ' ' | strip | truncate: 400 %}
+                        - **Summary:** {{ summary_line }}
+                        {%- endif %}
+                          {%- when 'ssl_cert' %}
+                        {%- if a.subject.CN != blank or a.issuer.CN != blank %}
+                        - **Certificate:** {% if a.subject.CN != blank %}CN={{ a.subject.CN }}{% endif %}{% if a.issuer.CN != blank %}, issued by {{ a.issuer.CN }}{% endif %}
+                        {%- endif %}
+                        {%- if a.validity.not_before != blank or a.validity.not_after != blank %}
+                        - **Valid:** {{ a.validity.not_before }} to {{ a.validity.not_after }}
+                        {%- endif %}
+                          {%- when 'graph' %}
+                        {%- if a.graph_data.description != blank %}
+                        - **Description:** {{ a.graph_data.description }}
+                        {%- endif %}
+                        {%- if a.nodes.size > 0 %}
+                        - **Nodes:** {{ a.nodes.size }}
+                        {%- endif %}
+                        {%- if a.creation_date != blank %}
+                        - **Created:** {{ a.creation_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- if a.views_count != blank or a.comments_count != blank %}
+                        - **Activity:** {{ a.views_count | default: 0 }} view(s), {{ a.comments_count | default: 0 }} comment(s)
+                        {%- endif %}
+                          {%- when 'whois' %}
+                        {%- if a.first_seen_date != blank %}
+                        - **First seen:** {{ a.first_seen_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- assign whois_pairs = a.whois_map | entries -%}
+                        {%- if whois_pairs.size > 0 %}
+                        - **WHOIS fields:**
+                        {%- for pair in whois_pairs limit: 10 %}
+                          - {{ pair.key }}: {{ pair.value }}
+                        {%- endfor %}
+                        {%- if whois_pairs.size > 10 %}
+                          - _(and {{ whois_pairs.size | minus: 10 }} more - see the full document)_
+                        {%- endif %}
+                        {%- endif %}
+                        {%- endcase %}
+                        {%- if stats != blank %}
+                        - **Last analysis:** {{ stats.malicious | default: 0 }} malicious, {{ stats.suspicious | default: 0 }} suspicious, {{ stats.harmless | default: 0 }} harmless, {{ stats.undetected | default: 0 }} undetected
+                        {%- endif %}
+                        {%- if a.reputation != blank %}
+                        - **Reputation:** {{ a.reputation }}
+                        {%- endif %}
+                        {%- if tags.size > 0 %}
+                        - **Tags:** {{ tags | join: ', ' }}
+                        {%- endif %}
+                        {% if steps.index_relationship_item.error != blank %}_Not indexed: this item's response could not be stored (see the workflow's execution log for detail)._{% elsif variables.doc_link_base != blank %}[Open {{ t }} document in Discover](<{{ variables.doc_link_base }}?id={{ variables.item_doc_id }}>){% else %}Full document in index `{{ consts.index }}`, document
+                        ```
+                        {{ variables.item_doc_id }}
+                        ```
+                        {% endif %}
+
+                  - name: wrap_note_section
+                    type: data.set
+                    with:
+                      item_note_section_arr: "${{ variables.item_note_section | split: '@@GTI_NOTE_SEP@@' }}"
+
+                  - name: accumulate_note_section
+                    type: data.set
+                    with:
+                      note_sections: "${{ variables.note_sections | concat: variables.item_note_section_arr }}"
+
+              - name: advance_cursor
+                type: data.set
+                with:
+                  any_success: true
+                  page_cursor: "{{ variables.page_next_cursor }}"
+                  collected: "${{ variables.collected | plus: variables.page_items.size }}"
+              - name: eval_has_more
+                type: data.set
+                with:
+                  has_more: "${{ variables.page_next_cursor != blank }}"
+
+          - name: handle_page_error
+            type: if
+            condition: "${{ steps.get_domain_relationship.error != blank }}"
+            steps:
+              - name: stop_on_error
+                type: data.set
+                with:
+                  has_more: false
+                  fetch_incomplete: true
+                  fetch_error: "${{ steps.get_domain_relationship.error }}"
+
+      - name: compute_truncated
+        type: data.set
+        with:
+          truncated: "${{ variables.has_more == true }}"
+
+      - name: compute_run_status
+        type: data.set
+        with:
+          run_status: "{% if variables.any_success != true %}failed{% elsif variables.fetch_incomplete == true or variables.truncated == true %}partial{% else %}succeeded{% endif %}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-run-summary' | sha256 }}"
+
+      - name: write_run_summary
+        type: if
+        condition: "${{ variables.run_status != 'succeeded' }}"
+        steps:
+          - name: index_run_summary
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.domain_relationship
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ variables.fetch_error.message }}"
+                  type: "{{ variables.fetch_error.type }}"
+                observable:
+                  type: domain
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                relationship: "{{ inputs.relationship }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                pagination:
+                  collected: "${{ variables.collected }}"
+                  fetch_incomplete: "${{ variables.fetch_incomplete }}"
+                  truncated: "${{ variables.truncated }}"
+                  next_cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              continue: true
+
+      - name: skip_on_total_failure
+        type: if
+        condition: "${{ variables.any_success != true }}"
+        steps:
+          - name: log_fetch_failure
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getDomainRelationship failed for {{ variables.field_name }} ({{ variables.observable }}), relationship {{ inputs.relationship }}.
+                {{ variables.fetch_error | json }}
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI Domain Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI Domain Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                    _Managed by the GTI Domain Relationships workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View domain on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve any data from GTI.
+                    > `{{ variables.fetch_error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: skip_when_empty
+        type: if
+        condition: "${{ variables.collected == 0 }}"
+        steps:
+          - name: log_empty
+            type: console
+            with:
+              message: >-
+                GTI has no {{ inputs.relationship }} relationship data for {{ variables.observable }}.
+                Nothing written.
+          - name: skip_empty_iteration
+            type: loop.continue
+
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and variables.collected > 0 }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI Domain Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI Domain Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                _Managed by the GTI Domain Relationships workflow. This note is replaced on every run and describes only what this run fetched; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View domain on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                **STATUS: {{ variables.run_status }}.** {{ variables.collected }} {{ inputs.relationship }} object(s) retrieved.
+
+                {%- if variables.fetch_incomplete %}
+
+                > **Incomplete:** retrieval stopped early because a GTI API request failed; results below may be missing further items.
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+
+                > **Unexpectedly large result set:** stopped after {{ variables.collected }} items as a safety limit; GTI still had more to page through. Re-run standalone with `cursor: {{ variables.page_cursor }}` to continue.
+                {%- endif %}
+
+                {%- for section in variables.note_sections %}
+                {{ section }}
+                {% endfor %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:domain-relationship"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank and variables.collected > 0 }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: {{ variables.run_status }} - GTI domain relationship {{ inputs.relationship }} for {{ variables.observable }}: {{ variables.collected }} object(s) retrieved.
+                {%- if variables.fetch_incomplete %}
+                (retrieval stopped early due to a GTI API error; results may be incomplete)
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+                (safety limit reached after {{ variables.collected }} items; GTI still had more - re-run with cursor: {{ variables.page_cursor }} to continue)
+                {%- endif %}
+                Indexed to {{ consts.index }}, one document per related object.

--- a/examples/integrations/google-threat-intelligence/gti-domain-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-domain-relationships.yaml
@@ -188,11 +188,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.domain != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-domain-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-domain-report.yaml
@@ -144,11 +144,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.domain != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-domain-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-domain-report.yaml
@@ -1,0 +1,590 @@
+# Retrieves the GTI reputation and detection report for a domain name and
+# indexes the full response. When run against an alert (paths 1/2) it also
+# writes a summary note and an alert tag; a standalone run (path 3) only
+# indexes. Failure handling, index bootstrapping, and note structure all
+# follow the same pattern as GTI IP Address Report.
+version: '1'
+name: GTI Domain Report
+description: >-
+  Retrieve the Google Threat Intelligence reputation and detection report for
+  a domain name. Indexes the full response and summarises it on the
+  triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - domain-report
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-domain-report
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["url.domain", "dns.question.name", "destination.domain", "source.domain"]
+  gti_ui_base: https://www.virustotal.com/gui/domain
+  empty_arr: []
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: domain
+        type: string
+        required: false
+        description: >-
+          Domain name, e.g. "example.com". Leave blank when running against
+          an alert, the domain is read from the alert instead.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.domain != blank -%}
+        {"field":"manual","value":"{{ inputs.domain | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable domain found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the domain input. Nothing to look up.
+
+  - name: enrich_each_domain
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_observable
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | append: '-run-summary' | sha256 }}"
+
+      - name: get_domain_report
+        type: google_threat_intelligence.getDomainReport
+        connector-id: "{{ consts.gti_connector_id }}"
+        with:
+          domain: "{{ foreach.item.value }}"
+        on-failure:
+          retry:
+            max-attempts: 2
+            delay: 3s
+          continue: true
+
+      - name: skip_on_fetch_error
+        type: if
+        condition: "${{ steps.get_domain_report.error != blank }}"
+        steps:
+          - name: log_fetch_error
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getDomainReport failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ steps.get_domain_report.error | json }}
+
+          - name: write_fetch_failure
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.domain_report
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ steps.get_domain_report.error.message }}"
+                  type: "{{ steps.get_domain_report.error.type }}"
+                observable:
+                  type: domain
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+            on-failure:
+              continue: true
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI Domain Report: ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI Domain Report: {{ variables.observable }}
+
+                    _Managed by the GTI Domain Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View domain on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve data from GTI.
+                    > `{{ steps.get_domain_report.error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: stash_iter
+        type: data.set
+        with:
+          attrs: "${{ steps.get_domain_report.output.data.attributes }}"
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+
+      # categories/popularity_ranks are vendor-name-keyed maps, flattened via entries so
+      # a new vendor never grows this summary block's own field count.
+      - name: summarise
+        type: data.set
+        with:
+          verdict: "{{ variables.attrs.gti_assessment.verdict.value | default: 'UNKNOWN' }}"
+          severity: "{{ variables.attrs.gti_assessment.severity.value | default: 'UNKNOWN' }}"
+          threat_score: "{{ variables.attrs.gti_assessment.threat_score.value | default: 0 }}"
+          description: "{{ variables.attrs.gti_assessment.description | replace: '\n', ' ' | replace: '  ', ' ' | strip }}"
+          malicious_count: "{{ variables.attrs.last_analysis_stats.malicious | default: 0 }}"
+          suspicious_count: "{{ variables.attrs.last_analysis_stats.suspicious | default: 0 }}"
+          harmless_count: "{{ variables.attrs.last_analysis_stats.harmless | default: 0 }}"
+          undetected_count: "{{ variables.attrs.last_analysis_stats.undetected | default: 0 }}"
+          last_analysis_date: "{{ variables.attrs.last_analysis_date }}"
+          reputation: "{{ variables.attrs.reputation | default: 0 }}"
+          votes_harmless: "{{ variables.attrs.total_votes.harmless | default: 0 }}"
+          votes_malicious: "{{ variables.attrs.total_votes.malicious | default: 0 }}"
+          registrar: "{{ variables.attrs.registrar }}"
+          tld: "{{ variables.attrs.tld }}"
+          creation_date: "{{ variables.attrs.creation_date }}"
+          expiration_date: "{{ variables.attrs.expiration_date }}"
+          tags: "${{ variables.attrs.tags }}"
+          crowdsourced_context: "${{ variables.attrs.crowdsourced_context | default: consts.empty_arr }}"
+          categories_list: |-
+            {%- assign cats = variables.attrs.categories | default: consts.empty_arr | entries -%}
+            {%- for pair in cats -%}
+              {%- if forloop.first == false %}, {% endif -%}{{ pair.key }}: {{ pair.value }}
+            {%- endfor -%}
+          top_popularity: |-
+            {%- assign ranks = variables.attrs.popularity_ranks | default: consts.empty_arr | entries -%}
+            {%- for pair in ranks -%}
+              {%- if forloop.first == false %}, {% endif -%}{{ pair.key }} #{{ pair.value.rank }}
+            {%- endfor -%}
+          whois_excerpt: "{{ variables.attrs.whois | strip_newlines | truncate: 400 }}"
+
+      - name: index_enrichment
+        type: elasticsearch.index
+        with:
+          index: "{{ consts.index }}"
+          id: "{{ variables.doc_id }}"
+          document:
+            "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+            event:
+              kind: enrichment
+              category: threat
+              dataset: gti_soar.domain_report
+            observable:
+              type: domain
+              field: "{{ variables.field_name }}"
+              value: "{{ variables.observable }}"
+            trigger_mode: "{{ variables.trigger_mode }}"
+            kibana:
+              alert:
+                uuid: "{{ variables.target_id }}"
+                index: "{{ variables.target_index }}"
+            rule:
+              id: "{{ variables.rule_id }}"
+              name: "{{ variables.rule_name }}"
+            workflow:
+              execution_id: "{{ execution.id }}"
+            summary:
+              verdict: "{{ variables.verdict }}"
+              severity: "{{ variables.severity }}"
+              description: "{{ variables.description }}"
+              threat_score: "${{ variables.threat_score | plus: 0 }}"
+              malicious_count: "${{ variables.malicious_count | plus: 0 }}"
+              suspicious_count: "${{ variables.suspicious_count | plus: 0 }}"
+              harmless_count: "${{ variables.harmless_count | plus: 0 }}"
+              undetected_count: "${{ variables.undetected_count | plus: 0 }}"
+              last_analysis_date: "{{ variables.last_analysis_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+              reputation: "${{ variables.reputation | plus: 0 }}"
+              votes_harmless: "${{ variables.votes_harmless | plus: 0 }}"
+              votes_malicious: "${{ variables.votes_malicious | plus: 0 }}"
+              registrar: "{{ variables.registrar }}"
+              tld: "{{ variables.tld }}"
+              creation_date: "{{ variables.creation_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+              expiration_date: "{{ variables.expiration_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+              tags: "${{ variables.tags }}"
+              categories: "{{ variables.categories_list }}"
+              top_popularity: "{{ variables.top_popularity }}"
+              crowdsourced_context: "${{ variables.crowdsourced_context }}"
+            gti: "${{ steps.get_domain_report.output.data }}"
+        on-failure:
+          continue: true
+
+      # Paths 1/2 only, and only once the document actually exists.
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and steps.index_enrichment.error == blank }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: build_doc_link
+            type: data.set
+            with:
+              doc_link: |-
+                {%- if variables.data_view_id != blank -%}
+                  {%- assign sp = '' -%}
+                  {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                  {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.doc_id }}
+                {%- endif -%}
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI Domain Report: ' | append: variables.observable -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI Domain Report: {{ variables.observable }}
+
+                _Managed by the GTI Domain Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View domain on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                ### Assessment
+                - **Verdict:** {{ variables.verdict }}
+                - **Severity:** {{ variables.severity }}
+                - **Threat score:** {{ variables.threat_score }}
+                - **Reputation:** {{ variables.reputation }}
+                {%- if variables.description != blank %}
+                - **GTI summary:** {{ variables.description }}
+                {%- endif %}
+
+                ### Detection
+                - **Last analysis:** {{ variables.malicious_count }} malicious, {{ variables.suspicious_count }} suspicious, {{ variables.harmless_count }} harmless, {{ variables.undetected_count }} undetected{% if variables.last_analysis_date != blank %} (as of {{ variables.last_analysis_date | date: '%Y-%m-%d' }}){% endif %}
+                {%- if variables.votes_harmless != blank or variables.votes_malicious != blank %}
+                - **Community votes:** {{ variables.votes_harmless | default: 0 }} harmless, {{ variables.votes_malicious | default: 0 }} malicious
+                {%- endif %}
+                {%- if variables.registrar != blank or variables.tld != blank or variables.creation_date != blank or variables.expiration_date != blank %}
+
+                ### Domain info
+                {%- if variables.registrar != blank %}
+                - **Registrar:** {{ variables.registrar }}
+                {%- endif %}
+                {%- if variables.tld != blank %}
+                - **TLD:** {{ variables.tld }}
+                {%- endif %}
+                {%- if variables.creation_date != blank %}
+                - **Created:** {{ variables.creation_date | date: '%Y-%m-%d' }}
+                {%- endif %}
+                {%- if variables.expiration_date != blank %}
+                - **Expires:** {{ variables.expiration_date | date: '%Y-%m-%d' }}
+                {%- endif %}
+                {%- endif %}
+                {%- if variables.top_popularity != blank %}
+
+                ### Popularity
+                - {{ variables.top_popularity }}
+                {%- endif %}
+                {%- if variables.categories_list != blank %}
+
+                ### Categories
+                - {{ variables.categories_list }}
+                {%- endif %}
+                {%- if variables.tags.size > 0 %}
+
+                ### Tags
+                - {{ variables.tags | join: ', ' }}
+                {%- endif %}
+                {%- if variables.crowdsourced_context.size > 0 %}
+
+                ### Community context
+                {%- for c in variables.crowdsourced_context %}
+                {%- assign detail_line = c.details | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                - **{{ c.title }}** ({{ c.severity | default: 'unknown' }} severity, via {{ c.source }}){% if c.timestamp != blank %}, {{ c.timestamp | date: '%Y-%m-%d' }}{% endif %}: {{ detail_line }}
+                {%- endfor %}
+                {%- endif %}
+                {%- if variables.whois_excerpt != blank %}
+
+                ### WHOIS (excerpt)
+                {{ variables.whois_excerpt }}
+                {%- endif %}
+
+                ---
+                {% if variables.doc_link != blank %}Full response: [open the stored document in Discover](<{{ variables.doc_link }}>){% else %}Full response in index `{{ consts.index }}`, document
+                ```
+                {{ variables.doc_id }}
+                ```
+                {% endif %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:domain-report"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: succeeded - GTI domain report for {{ variables.observable }}: verdict {{ variables.verdict }}, severity {{ variables.severity }}.
+                Indexed to {{ consts.index }} / {{ variables.doc_id }}

--- a/examples/integrations/google-threat-intelligence/gti-file-hash-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-file-hash-relationships.yaml
@@ -1,0 +1,776 @@
+# Retrieves objects related to a file by relationship type (e.g.
+# contacted_domains, bundled_files, behaviours - 49 values, the largest of
+# the four GTI relationship actions), paging until GTI has no more to give,
+# and indexes every related object as its own document. Writes one summary
+# note (one section per item) and an alert tag when run against an alert.
+# Manual only, same reasoning as GTI IP Address Relationships.
+version: '1'
+name: GTI File Hash Relationships
+description: >-
+  Retrieve objects related to a file by relationship type (e.g. contacted
+  domains, dropped files, sandbox behaviours), paging until GTI has no more
+  to give. Indexes every related object as its own document and summarises
+  the whole fetched batch on the triggering alert. Manual only; not attached
+  to a detection rule.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - file-relationship
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-file-relationship
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["file.hash.sha256", "process.hash.sha256", "dll.hash.sha256"]
+  gti_ui_base: https://www.virustotal.com/gui/file
+  empty_arr: []
+  page_size: 40
+
+triggers:
+  - type: manual
+    inputs:
+      - name: file_hash
+        type: string
+        required: false
+        description: >-
+          SHA-256, SHA-1, or MD5 hash of the file. Leave blank when running
+          against an alert, the hash is read from the alert instead.
+      # Safe to require: this workflow has no alert trigger, so there's no automatic
+      # run this could ever block.
+      - name: relationship
+        type: string
+        required: true
+        description: >-
+          Relationship to retrieve, e.g. "contacted_domains",
+          "bundled_files", or "behaviours". GTI validates this against its
+          own current set for file objects and returns a 404 for a value it
+          does not recognize; the workflow surfaces that as a skipped hash
+          rather than a failed run. Full current list:
+          https://gtidocs.virustotal.com/reference/files-object#relationships
+      - name: limit
+        type: number
+        required: false
+        description: >-
+          Page size for each internal GTI fetch while paging (advanced,
+          rarely needed - defaults to 40, GTI's own maximum for this
+          endpoint). This does not cap the total number of items collected:
+          the workflow still pages until GTI reports no more, or the safety
+          backstop (250 pages, see the paginate step) is hit; it only changes
+          how many items are requested per underlying API call.
+      - name: cursor
+        type: string
+        required: false
+        description: >-
+          Continuation cursor from a previous standalone run's
+          pagination.next_cursor (only meaningful together with file_hash,
+          when a prior run hit the safety backstop below and left more items
+          unfetched). Ignored on every other run - an alert-attached run
+          always pages from the start.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write. Same reasoning and settings as
+  # gti-ip-address-relationships.yaml's bootstrap_index_template step.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_doc_link_base
+    type: data.set
+    with:
+      doc_link_base: |-
+        {%- if variables.data_view_id != blank -%}
+          {%- assign sp = '' -%}
+          {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+          {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.file_hash != blank -%}
+        {"field":"manual","value":"{{ inputs.file_hash | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable file hash found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the file_hash input. Nothing to look up.
+
+  - name: enrich_each_hash
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_iter
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+
+      - name: init_pagination
+        type: data.set
+        with:
+          note_sections: "${{ consts.empty_arr }}"
+          page_cursor: "{%- if variables.target_id == blank -%}{{ inputs.cursor }}{%- endif -%}"
+          has_more: true
+          collected: 0
+          any_success: false
+          fetch_incomplete: false
+
+      - name: paginate
+        type: while
+        condition: "${{ variables.has_more == true }}"
+        # Backstop only (GTI's own cursor going blank is the real stop condition), so a
+        # vendor-side cursor bug can't loop forever. `max-iterations` only accepts a literal
+        # number or {limit, on-limit} - not a template - so this can't be pulled from consts.
+        max-iterations: 250
+        steps:
+
+          - name: get_file_relationship
+            type: google_threat_intelligence.getFileRelationship
+            connector-id: "{{ consts.gti_connector_id }}"
+            with:
+              fileHash: "{{ variables.observable }}"
+              relationship: "{{ inputs.relationship }}"
+              limit: "${{ inputs.limit | default: consts.page_size }}"
+              cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              retry:
+                max-attempts: 2
+                delay: 3s
+              continue: true
+
+          - name: collect_page
+            type: if
+            condition: "${{ steps.get_file_relationship.error == blank }}"
+            steps:
+              # Defensive: no current file relationship type is single-object, but GTI could add one
+              - name: stash_page
+                type: if
+                condition: "${{ steps.get_file_relationship.output.data.id != blank }}"
+                steps:
+                  - name: stash_single_item
+                    type: data.set
+                    with:
+                      page_items: "${{ consts.empty_arr | push: steps.get_file_relationship.output.data }}"
+                      page_next_cursor: "{{ steps.get_file_relationship.output.meta.cursor }}"
+                else:
+                  - name: stash_array_items
+                    type: data.set
+                    with:
+                      page_items: "${{ steps.get_file_relationship.output.data | default: consts.empty_arr }}"
+                      page_next_cursor: "{{ steps.get_file_relationship.output.meta.cursor }}"
+
+              - name: index_page_items
+                type: foreach
+                foreach: "${{ variables.page_items }}"
+                steps:
+                  - name: compute_item_doc_id
+                    type: data.set
+                    with:
+                      item_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-' | append: foreach.item.id | sha256 }}"
+
+                  - name: index_relationship_item
+                    type: elasticsearch.index
+                    with:
+                      index: "{{ consts.index }}"
+                      id: "{{ variables.item_doc_id }}"
+                      document:
+                        "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                        event:
+                          kind: enrichment
+                          category: threat
+                          dataset: gti_soar.file_relationship
+                        observable:
+                          type: file_hash
+                          field: "{{ variables.field_name }}"
+                          value: "{{ variables.observable }}"
+                        relationship: "{{ inputs.relationship }}"
+                        trigger_mode: "{{ variables.trigger_mode }}"
+                        kibana:
+                          alert:
+                            uuid: "{{ variables.target_id }}"
+                            index: "{{ variables.target_index }}"
+                        rule:
+                          id: "{{ variables.rule_id }}"
+                          name: "{{ variables.rule_name }}"
+                        workflow:
+                          execution_id: "{{ execution.id }}"
+                        summary:
+                          related_object_id: "{{ foreach.item.id }}"
+                          related_object_type: "{{ foreach.item.type }}"
+                          reputation: "${{ foreach.item.attributes.reputation | plus: 0 }}"
+                          tags: "${{ foreach.item.attributes.tags | default: consts.empty_arr }}"
+                        gti: "${{ foreach.item }}"
+                    on-failure:
+                      continue: true
+
+                  # Type-aware per-item section - reuses the cases from GTI IP
+                  # Address Relationships and GTI Domain Relationships, plus
+                  # two new to this action: 'ip_address' (same shape as GTI
+                  # IP Address Report) and 'file_behaviour' (same shape as
+                  # GTI File Sandbox Behaviour). Any type not covered
+                  # (analysis, attack_techniques, screenshot, submission -
+                  # not confirmed populated on any hash tried) falls through
+                  # to the generic fields below.
+                  - name: build_item_note_section
+                    type: data.set
+                    with:
+                      item_note_section: |-
+                        {%- assign a = foreach.item.attributes -%}
+                        {%- assign t = foreach.item.type -%}
+                        {%- assign stats = a.last_analysis_stats -%}
+                        {%- assign tags = a.tags | default: consts.empty_arr -%}
+                        ### {{ t }}: {{ foreach.item.id }}
+                        {%- case t %}
+                          {%- when 'domain' %}
+                        {%- if a.threat_severity.threat_severity_level != blank %}
+                        - **Severity:** {{ a.threat_severity.threat_severity_level }}{% if a.threat_severity.level_description != blank %} ({{ a.threat_severity.level_description }}){% endif %}
+                        {%- endif %}
+                        {%- if a.tld != blank or a.registrar != blank %}
+                        - **Domain info:** {% if a.tld != blank %}TLD {{ a.tld }}{% endif %}{% if a.registrar != blank %}{% if a.tld != blank %}, {% endif %}registrar {{ a.registrar }}{% endif %}
+                        {%- endif %}
+                          {%- when 'ip_address' %}
+                        {%- if a.as_owner != blank or a.asn != blank or a.network != blank %}
+                        - **Network:** {% if a.as_owner != blank %}{{ a.as_owner }}{% endif %}{% if a.asn != blank %} (AS{{ a.asn }}){% endif %}{% if a.network != blank %}, {{ a.network }}{% endif %}
+                        {%- endif %}
+                        {%- if a.country != blank or a.continent != blank %}
+                        - **Geolocation:** {% if a.country != blank %}{{ a.country }}{% endif %}{% if a.continent != blank %}, {{ a.continent }}{% endif %}
+                        {%- endif %}
+                          {%- when 'file_behaviour' %}
+                        {%- if a.sandbox_name != blank %}
+                        - **Sandbox:** {{ a.sandbox_name }}
+                        {%- endif %}
+                        {%- if a.verdicts.size > 0 %}
+                        - **Verdicts:** {{ a.verdicts | join: ', ' }}
+                        {%- endif %}
+                        {%- if a.analysis_date != blank %}
+                        - **Analysis date:** {{ a.analysis_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'resolution' %}
+                        {%- if a.host_name != blank %}
+                        - **Host name:** {{ a.host_name }}
+                        {%- endif %}
+                        {%- if a.date != blank %}
+                        - **Resolved:** {{ a.date | date: '%Y-%m-%d' }}{% if a.resolver != blank %} via {{ a.resolver }}{% endif %}
+                        {%- endif %}
+                          {%- when 'file' %}
+                        {%- assign fname = a.meaningful_name | default: a.names[0] -%}
+                        {%- if fname != blank %}
+                        - **Name:** {{ fname }}
+                        {%- endif %}
+                        {%- if a.type_description != blank or a.size != blank %}
+                        - **Type:** {% if a.type_description != blank %}{{ a.type_description }}{% endif %}{% if a.size != blank %}, {{ a.size }} bytes{% endif %}
+                        {%- endif %}
+                        {%- if a.first_submission_date != blank %}
+                        - **First submitted:** {{ a.first_submission_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'url' %}
+                        {%- if a.title != blank %}
+                        - **Title:** {{ a.title }}
+                        {%- endif %}
+                        {%- if a.last_final_url != blank %}
+                        - **Final URL:** {{ a.last_final_url }}
+                        {%- endif %}
+                        {%- if a.threat_names.size > 0 %}
+                        - **Threat names:** {{ a.threat_names | join: ', ' }}
+                        {%- endif %}
+                          {%- when 'vote' %}
+                        - **Verdict:** {{ a.verdict }}{% if a.value != blank %} (value {{ a.value }}){% endif %}
+                        {%- if a.date != blank %}
+                        - **Date:** {{ a.date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'comment' %}
+                        {%- assign comment_line = a.text | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                        - **Comment:** {{ comment_line }}
+                          {%- when 'collection' %}
+                        {%- if a.name != blank %}
+                        - **Name:** {{ a.name }}
+                        {%- endif %}
+                        {%- if a.collection_type != blank %}
+                        - **Type:** {{ a.collection_type }}
+                        {%- endif %}
+                        {%- assign summary_raw = a.executive_summary | default: a.analyst_comment | default: a.description -%}
+                        {%- if summary_raw != blank %}
+                        {%- assign summary_line = summary_raw | strip_html | replace: '\n', ' ' | replace: '  ', ' ' | strip | truncate: 400 %}
+                        - **Summary:** {{ summary_line }}
+                        {%- endif %}
+                          {%- when 'ssl_cert' %}
+                        {%- if a.subject.CN != blank or a.issuer.CN != blank %}
+                        - **Certificate:** {% if a.subject.CN != blank %}CN={{ a.subject.CN }}{% endif %}{% if a.issuer.CN != blank %}, issued by {{ a.issuer.CN }}{% endif %}
+                        {%- endif %}
+                        {%- if a.validity.not_before != blank or a.validity.not_after != blank %}
+                        - **Valid:** {{ a.validity.not_before }} to {{ a.validity.not_after }}
+                        {%- endif %}
+                          {%- when 'graph' %}
+                        {%- if a.graph_data.description != blank %}
+                        - **Description:** {{ a.graph_data.description }}
+                        {%- endif %}
+                        {%- if a.nodes.size > 0 %}
+                        - **Nodes:** {{ a.nodes.size }}
+                        {%- endif %}
+                        {%- if a.creation_date != blank %}
+                        - **Created:** {{ a.creation_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- if a.views_count != blank or a.comments_count != blank %}
+                        - **Activity:** {{ a.views_count | default: 0 }} view(s), {{ a.comments_count | default: 0 }} comment(s)
+                        {%- endif %}
+                          {%- when 'whois' %}
+                        {%- if a.first_seen_date != blank %}
+                        - **First seen:** {{ a.first_seen_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- assign whois_pairs = a.whois_map | entries -%}
+                        {%- if whois_pairs.size > 0 %}
+                        - **WHOIS fields:**
+                        {%- for pair in whois_pairs limit: 10 %}
+                          - {{ pair.key }}: {{ pair.value }}
+                        {%- endfor %}
+                        {%- if whois_pairs.size > 10 %}
+                          - _(and {{ whois_pairs.size | minus: 10 }} more - see the full document)_
+                        {%- endif %}
+                        {%- endif %}
+                        {%- endcase %}
+                        {%- if stats != blank %}
+                        - **Last analysis:** {{ stats.malicious | default: 0 }} malicious, {{ stats.suspicious | default: 0 }} suspicious, {{ stats.harmless | default: 0 }} harmless, {{ stats.undetected | default: 0 }} undetected
+                        {%- endif %}
+                        {%- if a.reputation != blank %}
+                        - **Reputation:** {{ a.reputation }}
+                        {%- endif %}
+                        {%- if tags.size > 0 %}
+                        - **Tags:** {{ tags | join: ', ' }}
+                        {%- endif %}
+                        {% if steps.index_relationship_item.error != blank %}_Not indexed: this item's response could not be stored (see the workflow's execution log for detail)._{% elsif variables.doc_link_base != blank %}[Open {{ t }} document in Discover](<{{ variables.doc_link_base }}?id={{ variables.item_doc_id }}>){% else %}Full document in index `{{ consts.index }}`, document
+                        ```
+                        {{ variables.item_doc_id }}
+                        ```
+                        {% endif %}
+
+                  - name: wrap_note_section
+                    type: data.set
+                    with:
+                      item_note_section_arr: "${{ variables.item_note_section | split: '@@GTI_NOTE_SEP@@' }}"
+
+                  - name: accumulate_note_section
+                    type: data.set
+                    with:
+                      note_sections: "${{ variables.note_sections | concat: variables.item_note_section_arr }}"
+
+              - name: advance_cursor
+                type: data.set
+                with:
+                  any_success: true
+                  page_cursor: "{{ variables.page_next_cursor }}"
+                  collected: "${{ variables.collected | plus: variables.page_items.size }}"
+              - name: eval_has_more
+                type: data.set
+                with:
+                  has_more: "${{ variables.page_next_cursor != blank }}"
+
+          - name: handle_page_error
+            type: if
+            condition: "${{ steps.get_file_relationship.error != blank }}"
+            steps:
+              - name: stop_on_error
+                type: data.set
+                with:
+                  has_more: false
+                  fetch_incomplete: true
+                  fetch_error: "${{ steps.get_file_relationship.error }}"
+
+      - name: compute_truncated
+        type: data.set
+        with:
+          truncated: "${{ variables.has_more == true }}"
+
+      - name: compute_run_status
+        type: data.set
+        with:
+          run_status: "{% if variables.any_success != true %}failed{% elsif variables.fetch_incomplete == true or variables.truncated == true %}partial{% else %}succeeded{% endif %}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-run-summary' | sha256 }}"
+
+      - name: write_run_summary
+        type: if
+        condition: "${{ variables.run_status != 'succeeded' }}"
+        steps:
+          - name: index_run_summary
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.file_relationship
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ variables.fetch_error.message }}"
+                  type: "{{ variables.fetch_error.type }}"
+                observable:
+                  type: file_hash
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                relationship: "{{ inputs.relationship }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                pagination:
+                  collected: "${{ variables.collected }}"
+                  fetch_incomplete: "${{ variables.fetch_incomplete }}"
+                  truncated: "${{ variables.truncated }}"
+                  next_cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              continue: true
+
+      - name: skip_on_total_failure
+        type: if
+        condition: "${{ variables.any_success != true }}"
+        steps:
+          - name: log_fetch_failure
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getFileRelationship failed for {{ variables.field_name }} ({{ variables.observable }}), relationship {{ inputs.relationship }}.
+                {{ variables.fetch_error | json }}
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI File Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI File Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                    _Managed by the GTI File Hash Relationships workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View file on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve any data from GTI.
+                    > `{{ variables.fetch_error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: skip_when_empty
+        type: if
+        condition: "${{ variables.collected == 0 }}"
+        steps:
+          - name: log_empty
+            type: console
+            with:
+              message: >-
+                GTI has no {{ inputs.relationship }} relationship data for {{ variables.observable }}.
+                Nothing written.
+          - name: skip_empty_iteration
+            type: loop.continue
+
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and variables.collected > 0 }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI File Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI File Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                _Managed by the GTI File Hash Relationships workflow. This note is replaced on every run and describes only what this run fetched; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View file on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                **STATUS: {{ variables.run_status }}.** {{ variables.collected }} {{ inputs.relationship }} object(s) retrieved.
+
+                {%- if variables.fetch_incomplete %}
+
+                > **Incomplete:** retrieval stopped early because a GTI API request failed; results below may be missing further items.
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+
+                > **Unexpectedly large result set:** stopped after {{ variables.collected }} items as a safety limit; GTI still had more to page through. Re-run standalone with `cursor: {{ variables.page_cursor }}` to continue.
+                {%- endif %}
+
+                {%- for section in variables.note_sections %}
+                {{ section }}
+                {% endfor %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:file-relationship"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank and variables.collected > 0 }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: {{ variables.run_status }} - GTI file relationship {{ inputs.relationship }} for {{ variables.observable }}: {{ variables.collected }} object(s) retrieved.
+                {%- if variables.fetch_incomplete %}
+                (retrieval stopped early due to a GTI API error; results may be incomplete)
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+                (safety limit reached after {{ variables.collected }} items; GTI still had more - re-run with cursor: {{ variables.page_cursor }} to continue)
+                {%- endif %}
+                Indexed to {{ consts.index }}, one document per related object.

--- a/examples/integrations/google-threat-intelligence/gti-file-hash-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-file-hash-relationships.yaml
@@ -188,11 +188,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.file_hash != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-file-hash-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-file-hash-report.yaml
@@ -145,11 +145,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.file_hash != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-file-hash-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-file-hash-report.yaml
@@ -1,0 +1,576 @@
+# Retrieves the GTI reputation and detection report for a file by hash and
+# indexes the full response. When run against an alert (paths 1/2) it also
+# writes a summary note and an alert tag; a standalone run (path 3) only
+# indexes. A different action from File Sandbox Behaviour (sandbox
+# detonation) and MITRE ATT&CK Techniques (technique tree) - this is the
+# reputation/detection report.
+version: '1'
+name: GTI File Hash Report
+description: >-
+  Retrieve the Google Threat Intelligence reputation and detection report for
+  a file by hash (SHA-256, SHA-1, or MD5). Indexes the full response and
+  summarises it on the triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - file-report
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-file-report
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["file.hash.sha256", "process.hash.sha256", "dll.hash.sha256"]
+  gti_ui_base: https://www.virustotal.com/gui/file
+  empty_arr: []
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: file_hash
+        type: string
+        required: false
+        description: >-
+          SHA-256, SHA-1, or MD5 hash of the file. Leave blank when running
+          against an alert, the hash is read from the alert instead.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.file_hash != blank -%}
+        {"field":"manual","value":"{{ inputs.file_hash | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable file hash found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the file_hash input. Nothing to look up.
+
+  - name: enrich_each_hash
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_observable
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | append: '-run-summary' | sha256 }}"
+
+      - name: get_file_report
+        type: google_threat_intelligence.getFileReport
+        connector-id: "{{ consts.gti_connector_id }}"
+        with:
+          fileHash: "{{ foreach.item.value }}"
+        on-failure:
+          retry:
+            max-attempts: 2
+            delay: 3s
+          continue: true
+
+      - name: skip_on_fetch_error
+        type: if
+        condition: "${{ steps.get_file_report.error != blank }}"
+        steps:
+          - name: log_fetch_error
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getFileReport failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ steps.get_file_report.error | json }}
+
+          - name: write_fetch_failure
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.file_report
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ steps.get_file_report.error.message }}"
+                  type: "{{ steps.get_file_report.error.type }}"
+                observable:
+                  type: file_hash
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+            on-failure:
+              continue: true
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI File Report: ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI File Report: {{ variables.observable }}
+
+                    _Managed by the GTI File Hash Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View file on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve data from GTI.
+                    > `{{ steps.get_file_report.error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: stash_iter
+        type: data.set
+        with:
+          attrs: "${{ steps.get_file_report.output.data.attributes }}"
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+
+      - name: summarise
+        type: data.set
+        with:
+          verdict: "{{ variables.attrs.gti_assessment.verdict.value | default: 'UNKNOWN' }}"
+          severity: "{{ variables.attrs.gti_assessment.severity.value | default: 'UNKNOWN' }}"
+          threat_score: "{{ variables.attrs.gti_assessment.threat_score.value | default: 0 }}"
+          description: "{{ variables.attrs.gti_assessment.description | replace: '\n', ' ' | replace: '  ', ' ' | strip }}"
+          malicious_count: "{{ variables.attrs.last_analysis_stats.malicious | default: 0 }}"
+          suspicious_count: "{{ variables.attrs.last_analysis_stats.suspicious | default: 0 }}"
+          harmless_count: "{{ variables.attrs.last_analysis_stats.harmless | default: 0 }}"
+          undetected_count: "{{ variables.attrs.last_analysis_stats.undetected | default: 0 }}"
+          last_analysis_date: "{{ variables.attrs.last_analysis_date }}"
+          reputation: "{{ variables.attrs.reputation | default: 0 }}"
+          votes_harmless: "{{ variables.attrs.total_votes.harmless | default: 0 }}"
+          votes_malicious: "{{ variables.attrs.total_votes.malicious | default: 0 }}"
+          type_description: "{{ variables.attrs.type_description }}"
+          meaningful_name: "{{ variables.attrs.meaningful_name }}"
+          file_size: "{{ variables.attrs.size | default: 0 }}"
+          suggested_threat_label: "{{ variables.attrs.popular_threat_classification.suggested_threat_label }}"
+          tags: "${{ variables.attrs.tags }}"
+          crowdsourced_context: "${{ variables.attrs.crowdsourced_context | default: consts.empty_arr }}"
+          top_threat_names: |-
+            {%- assign items = variables.attrs.popular_threat_classification.popular_threat_name | default: consts.empty_arr -%}
+            {%- for it in items limit: 5 -%}
+              {%- if forloop.first == false %}, {% endif -%}{{ it.value }} ({{ it.count }})
+            {%- endfor -%}
+          signature_product: "{{ variables.attrs.signature_info.product }}"
+          signature_description: "{{ variables.attrs.signature_info.description }}"
+
+      - name: index_enrichment
+        type: elasticsearch.index
+        with:
+          index: "{{ consts.index }}"
+          id: "{{ variables.doc_id }}"
+          document:
+            "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+            event:
+              kind: enrichment
+              category: threat
+              dataset: gti_soar.file_report
+            observable:
+              type: file_hash
+              field: "{{ variables.field_name }}"
+              value: "{{ variables.observable }}"
+            trigger_mode: "{{ variables.trigger_mode }}"
+            kibana:
+              alert:
+                uuid: "{{ variables.target_id }}"
+                index: "{{ variables.target_index }}"
+            rule:
+              id: "{{ variables.rule_id }}"
+              name: "{{ variables.rule_name }}"
+            workflow:
+              execution_id: "{{ execution.id }}"
+            summary:
+              verdict: "{{ variables.verdict }}"
+              severity: "{{ variables.severity }}"
+              description: "{{ variables.description }}"
+              threat_score: "${{ variables.threat_score | plus: 0 }}"
+              malicious_count: "${{ variables.malicious_count | plus: 0 }}"
+              suspicious_count: "${{ variables.suspicious_count | plus: 0 }}"
+              harmless_count: "${{ variables.harmless_count | plus: 0 }}"
+              undetected_count: "${{ variables.undetected_count | plus: 0 }}"
+              last_analysis_date: "{{ variables.last_analysis_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+              reputation: "${{ variables.reputation | plus: 0 }}"
+              votes_harmless: "${{ variables.votes_harmless | plus: 0 }}"
+              votes_malicious: "${{ variables.votes_malicious | plus: 0 }}"
+              type_description: "{{ variables.type_description }}"
+              meaningful_name: "{{ variables.meaningful_name }}"
+              file_size: "${{ variables.file_size | plus: 0 }}"
+              suggested_threat_label: "{{ variables.suggested_threat_label }}"
+              top_threat_names: "{{ variables.top_threat_names }}"
+              signature_product: "{{ variables.signature_product }}"
+              tags: "${{ variables.tags }}"
+              crowdsourced_context: "${{ variables.crowdsourced_context }}"
+            gti: "${{ steps.get_file_report.output.data }}"
+        on-failure:
+          continue: true
+
+      # Paths 1/2 only, and only once the document actually exists.
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and steps.index_enrichment.error == blank }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: build_doc_link
+            type: data.set
+            with:
+              doc_link: |-
+                {%- if variables.data_view_id != blank -%}
+                  {%- assign sp = '' -%}
+                  {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                  {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.doc_id }}
+                {%- endif -%}
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI File Report: ' | append: variables.observable -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI File Report: {{ variables.observable }}
+
+                _Managed by the GTI File Hash Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View file on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                ### Assessment
+                - **Verdict:** {{ variables.verdict }}
+                - **Severity:** {{ variables.severity }}
+                - **Threat score:** {{ variables.threat_score }}
+                - **Reputation:** {{ variables.reputation }}
+                {%- if variables.suggested_threat_label != blank %}
+                - **Suggested label:** {{ variables.suggested_threat_label }}
+                {%- endif %}
+                {%- if variables.description != blank %}
+                - **GTI summary:** {{ variables.description }}
+                {%- endif %}
+
+                ### Detection
+                - **Last analysis:** {{ variables.malicious_count }} malicious, {{ variables.suspicious_count }} suspicious, {{ variables.harmless_count }} harmless, {{ variables.undetected_count }} undetected{% if variables.last_analysis_date != blank %} (as of {{ variables.last_analysis_date | date: '%Y-%m-%d' }}){% endif %}
+                {%- if variables.votes_harmless != blank or variables.votes_malicious != blank %}
+                - **Community votes:** {{ variables.votes_harmless | default: 0 }} harmless, {{ variables.votes_malicious | default: 0 }} malicious
+                {%- endif %}
+                {%- if variables.top_threat_names != blank %}
+                - **Popular threat names:** {{ variables.top_threat_names }}
+                {%- endif %}
+                {%- if variables.type_description != blank or variables.meaningful_name != blank or variables.file_size != blank %}
+
+                ### File info
+                {%- if variables.meaningful_name != blank %}
+                - **Name:** {{ variables.meaningful_name }}
+                {%- endif %}
+                {%- if variables.type_description != blank %}
+                - **Type:** {{ variables.type_description }}
+                {%- endif %}
+                {%- if variables.file_size != blank %}
+                - **Size:** {{ variables.file_size }} bytes
+                {%- endif %}
+                {%- if variables.signature_product != blank %}
+                - **Signed product:** {{ variables.signature_product }}{% if variables.signature_description != blank %} ({{ variables.signature_description }}){% endif %}
+                {%- endif %}
+                {%- endif %}
+                {%- if variables.tags.size > 0 %}
+
+                ### Tags
+                - {{ variables.tags | join: ', ' }}
+                {%- endif %}
+                {%- if variables.crowdsourced_context.size > 0 %}
+
+                ### Community context
+                {%- for c in variables.crowdsourced_context %}
+                {%- assign detail_line = c.details | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                - **{{ c.title }}** ({{ c.severity | default: 'unknown' }} severity, via {{ c.source }}){% if c.timestamp != blank %}, {{ c.timestamp | date: '%Y-%m-%d' }}{% endif %}: {{ detail_line }}
+                {%- endfor %}
+                {%- endif %}
+
+                ---
+                {% if variables.doc_link != blank %}Full response: [open the stored document in Discover](<{{ variables.doc_link }}>){% else %}Full response in index `{{ consts.index }}`, document
+                ```
+                {{ variables.doc_id }}
+                ```
+                {% endif %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:file-report"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: succeeded - GTI file report for {{ variables.observable }}: verdict {{ variables.verdict }}, severity {{ variables.severity }}.
+                Indexed to {{ consts.index }} / {{ variables.doc_id }}

--- a/examples/integrations/google-threat-intelligence/gti-file-sandbox-behaviour.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-file-sandbox-behaviour.yaml
@@ -1,0 +1,649 @@
+# Retrieves GTI sandbox detonation reports for a file hash, paging until GTI
+# has no more to give, and indexes every report as its own document. When
+# run against an alert (paths 1/2) it also writes one summary note (one
+# section per report) and an alert tag; a standalone run (path 3) only
+# indexes.
+version: '1'
+name: GTI File Sandbox Behaviour
+description: >-
+  Retrieve Google Threat Intelligence sandbox detonation reports for a file
+  hash, paging until GTI has no more to give. Indexes every report as its own
+  document and summarises the whole fetched batch on the triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - file-sandbox
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-file-behaviour
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["file.hash.sha256", "process.hash.sha256", "dll.hash.sha256"]
+  gti_ui_base: https://www.virustotal.com/gui/file
+  empty_arr: []
+  page_size: 40
+  # processes_tree excluded - it's recursive, a flat size count would undercount.
+  behaviour_activity_fields: "processes_created,processes_terminated,files_opened,files_written,registry_keys_set,registry_keys_opened,mutexes_created,modules_loaded,dns_lookups,command_executions,windows_hidden,mitre_attack_techniques,signature_matches,mbc"
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: file_hash
+        type: string
+        required: false
+        description: >-
+          SHA-256, SHA-1 or MD5 hash. Leave blank when running against an
+          alert, the hash is read from the alert instead.
+      - name: limit
+        type: number
+        required: false
+        description: >-
+          Page size for each internal GTI fetch while paging (advanced,
+          rarely needed - defaults to 40, GTI's own maximum for this
+          endpoint). This does not cap the total number of reports collected:
+          the workflow still pages until GTI reports no more, or the safety
+          backstop (250 pages, see the paginate step) is hit; it only changes
+          how many reports are requested per underlying API call.
+      - name: cursor
+        type: string
+        required: false
+        description: >-
+          Continuation cursor from a previous standalone run's
+          pagination.next_cursor (only meaningful together with file_hash,
+          when a prior run hit the safety backstop below and left more
+          reports unfetched). Ignored on every other run — an alert-attached
+          run always pages from the start.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to the GTI link alone if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_doc_link_base
+    type: data.set
+    with:
+      doc_link_base: |-
+        {%- if variables.data_view_id != blank -%}
+          {%- assign sp = '' -%}
+          {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+          {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}
+        {%- endif -%}
+
+  # Length check because the connector validates fileHash against a SHA-256/1/MD5 regex.
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- assign len = node | size -%}
+            {%- if len == 32 or len == 40 or len == 64 -%}
+              {%- unless seen contains node -%}
+                {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+                {%- assign sep = ',' -%}
+                {%- assign seen = seen | push: node -%}
+              {%- endunless -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.file_hash != blank -%}
+        {"field":"manual","value":"{{ inputs.file_hash | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable file hash found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the file_hash input. Nothing to look up.
+
+  - name: enrich_each_hash
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_iter
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+
+      - name: init_pagination
+        type: data.set
+        with:
+          note_sections: "${{ consts.empty_arr }}"
+          page_cursor: "{%- if variables.target_id == blank -%}{{ inputs.cursor }}{%- endif -%}"
+          has_more: true
+          collected: 0
+          any_success: false
+          fetch_incomplete: false
+          is_malicious: false
+
+      - name: paginate
+        type: while
+        condition: "${{ variables.has_more == true }}"
+        # Backstop only (GTI's own cursor going blank is the real stop condition), so a
+        # vendor-side cursor bug can't loop forever. `max-iterations` only accepts a literal
+        # number or {limit, on-limit} - not a template - so this can't be pulled from consts.
+        max-iterations: 250
+        steps:
+
+          - name: get_file_behaviours
+            type: google_threat_intelligence.getFileBehaviours
+            connector-id: "{{ consts.gti_connector_id }}"
+            with:
+              fileHash: "{{ variables.observable }}"
+              limit: "${{ inputs.limit | default: consts.page_size }}"
+              cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              retry:
+                max-attempts: 2
+                delay: 3s
+              continue: true
+
+          - name: collect_page
+            type: if
+            condition: "${{ steps.get_file_behaviours.error == blank }}"
+            steps:
+              - name: stash_page
+                type: data.set
+                with:
+                  page_items: "${{ steps.get_file_behaviours.output.data | default: consts.empty_arr }}"
+                  page_next_cursor: "{{ steps.get_file_behaviours.output.meta.cursor }}"
+
+              - name: index_page_items
+                type: foreach
+                foreach: "${{ variables.page_items }}"
+                steps:
+                  - name: compute_item_doc_id
+                    type: data.set
+                    with:
+                      item_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: foreach.item.id | sha256 }}"
+                      item_is_malicious: |-
+                        {%- assign iv = foreach.item.attributes.verdicts | default: consts.empty_arr -%}
+                        {%- if iv contains 'MALWARE' -%}true{%- else -%}false{%- endif -%}
+
+                  - name: index_report
+                    type: elasticsearch.index
+                    with:
+                      index: "{{ consts.index }}"
+                      id: "{{ variables.item_doc_id }}"
+                      document:
+                        "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                        event:
+                          kind: enrichment
+                          category: threat
+                          dataset: gti_soar.file_behaviour
+                        observable:
+                          type: file_hash
+                          field: "{{ variables.field_name }}"
+                          value: "{{ variables.observable }}"
+                        trigger_mode: "{{ variables.trigger_mode }}"
+                        kibana:
+                          alert:
+                            uuid: "{{ variables.target_id }}"
+                            index: "{{ variables.target_index }}"
+                        rule:
+                          id: "{{ variables.rule_id }}"
+                          name: "{{ variables.rule_name }}"
+                        workflow:
+                          execution_id: "{{ execution.id }}"
+                        summary:
+                          sandbox_name: "{{ foreach.item.attributes.sandbox_name }}"
+                          verdicts: "${{ foreach.item.attributes.verdicts | default: consts.empty_arr }}"
+                          is_malicious: "${{ variables.item_is_malicious }}"
+                          tags: "${{ foreach.item.attributes.tags | default: consts.empty_arr }}"
+                        gti: "${{ foreach.item }}"
+                    on-failure:
+                      continue: true
+
+                  - name: build_item_note_section
+                    type: data.set
+                    with:
+                      item_note_section: |-
+                        {%- assign v = foreach.item.attributes.verdicts | default: consts.empty_arr -%}
+                        {%- assign vc = foreach.item.attributes.verdict_confidence -%}
+                        {%- assign tags = foreach.item.attributes.tags | default: consts.empty_arr -%}
+                        {%- assign activity_fields = consts.behaviour_activity_fields | split: ',' -%}
+                        {%- assign has_activity = false -%}
+                        {%- for f in activity_fields -%}
+                          {%- assign arr = foreach.item.attributes[f] | default: consts.empty_arr -%}
+                          {%- if arr.size > 0 -%}{%- assign has_activity = true -%}{%- endif -%}
+                        {%- endfor %}
+                        ### {{ foreach.item.attributes.sandbox_name }}
+                        - **Analysis date:** {{ foreach.item.attributes.analysis_date | date: '%Y-%m-%d' }}
+                        - **Verdict:** {% if v.size > 0 %}{{ v | join: ', ' }}{% if vc != blank %} (confidence {{ vc }}){% endif %}{% else %}None{% endif %}
+                        - **Tags:** {% if tags.size > 0 %}{{ tags | join: ', ' }}{% else %}none{% endif %}
+
+                        **Activity:**
+                        {% if has_activity %}{% for f in activity_fields %}{% assign arr = foreach.item.attributes[f] | default: consts.empty_arr %}{% if arr.size > 0 %}{% assign label = f | replace: '_', ' ' | capitalize %}{% if f == 'dns_lookups' %}{% assign label = 'DNS lookups' %}{% elsif f == 'mbc' %}{% assign label = 'MBC (Malware Behavior Catalog) techniques' %}{% elsif f == 'mitre_attack_techniques' %}{% assign label = 'MITRE ATT&CK techniques' %}{% endif %}
+                        - {{ label }}: {{ arr.size }}
+                        {%- endif %}{% endfor %}{% else %}- no notable activity
+                        {% endif %}
+
+                        {% if variables.doc_link_base != blank %}[Open full document in Discover](<{{ variables.doc_link_base }}?id={{ variables.item_doc_id }}>){% else %}Full document in index `{{ consts.index }}`, document
+                        ```
+                        {{ variables.item_doc_id }}
+                        ```
+                        {% endif %}
+
+                  - name: wrap_note_section
+                    type: data.set
+                    with:
+                      item_note_section_arr: "${{ variables.item_note_section | split: '@@GTI_NOTE_SEP@@' }}"
+
+                  - name: accumulate_note_section
+                    type: data.set
+                    with:
+                      note_sections: "${{ variables.note_sections | concat: variables.item_note_section_arr }}"
+                      is_malicious: "${{ variables.is_malicious == true or variables.item_is_malicious == 'true' }}"
+
+              - name: advance_cursor
+                type: data.set
+                with:
+                  any_success: true
+                  page_cursor: "{{ variables.page_next_cursor }}"
+                  collected: "${{ variables.collected | plus: variables.page_items.size }}"
+              - name: eval_has_more
+                type: data.set
+                with:
+                  has_more: "${{ variables.page_next_cursor != blank }}"
+
+          - name: handle_page_error
+            type: if
+            condition: "${{ steps.get_file_behaviours.error != blank }}"
+            steps:
+              - name: stop_on_error
+                type: data.set
+                with:
+                  has_more: false
+                  fetch_incomplete: true
+                  fetch_error: "${{ steps.get_file_behaviours.error }}"
+
+      - name: compute_truncated
+        type: data.set
+        with:
+          truncated: "${{ variables.has_more == true }}"
+
+      - name: compute_run_status
+        type: data.set
+        with:
+          run_status: "{% if variables.any_success != true %}failed{% elsif variables.fetch_incomplete == true or variables.truncated == true %}partial{% else %}succeeded{% endif %}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-run-summary' | sha256 }}"
+
+      - name: write_run_summary
+        type: if
+        condition: "${{ variables.run_status != 'succeeded' }}"
+        steps:
+          - name: index_run_summary
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.file_behaviour
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ variables.fetch_error.message }}"
+                  type: "{{ variables.fetch_error.type }}"
+                observable:
+                  type: file_hash
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                pagination:
+                  collected: "${{ variables.collected }}"
+                  fetch_incomplete: "${{ variables.fetch_incomplete }}"
+                  truncated: "${{ variables.truncated }}"
+                  next_cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              continue: true
+
+      - name: skip_on_total_failure
+        type: if
+        condition: "${{ variables.any_success != true }}"
+        steps:
+          - name: log_fetch_failure
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getFileBehaviours failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ variables.fetch_error | json }}
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI File Sandbox: ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI File Sandbox: {{ variables.observable }}
+
+                    _Managed by the GTI File Sandbox Behaviour workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View full sandbox history on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }}/behavior)
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve any data from GTI.
+                    > `{{ variables.fetch_error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: skip_when_empty
+        type: if
+        condition: "${{ variables.collected == 0 }}"
+        steps:
+          - name: log_empty
+            type: console
+            with:
+              message: >-
+                GTI has no sandbox behaviour reports for {{ variables.observable }};
+                the file is known but has not been detonated. Nothing written.
+          - name: skip_empty_iteration
+            type: loop.continue
+
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and variables.collected > 0 }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI File Sandbox: ' | append: variables.observable -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI File Sandbox: {{ variables.observable }}
+
+                _Managed by the GTI File Sandbox Behaviour workflow. This note is replaced on every run and describes only what this run fetched; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View full sandbox history on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }}/behavior)
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                **STATUS: {{ variables.run_status }}.** {{ variables.collected }} sandbox report(s) retrieved{% if variables.is_malicious %}, at least one flagged **MALWARE**{% endif %}.
+
+                {%- if variables.fetch_incomplete %}
+
+                > **Incomplete:** retrieval stopped early because a GTI API request failed; results below may be missing further reports.
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+
+                > **Unexpectedly large result set:** stopped after {{ variables.collected }} reports as a safety limit; GTI still had more to page through. Re-run standalone with `cursor: {{ variables.page_cursor }}` to continue.
+                {%- endif %}
+
+                {%- for section in variables.note_sections %}
+                {{ section }}
+                {% endfor %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:file-sandbox"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank and variables.collected > 0 }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: {{ variables.run_status }} - GTI file sandbox behaviour for {{ variables.observable }}: {{ variables.collected }} report(s) retrieved{% if variables.is_malicious %}, at least one flagged MALWARE{% endif %}.
+                {%- if variables.fetch_incomplete %}
+                (retrieval stopped early due to a GTI API error; results may be incomplete)
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+                (safety limit reached after {{ variables.collected }} reports; GTI still had more — re-run with cursor: {{ variables.page_cursor }} to continue)
+                {%- endif %}
+                Indexed to {{ consts.index }}, one document per report.

--- a/examples/integrations/google-threat-intelligence/gti-file-sandbox-behaviour.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-file-sandbox-behaviour.yaml
@@ -177,14 +177,24 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- assign len = node | size -%}
-            {%- if len == 32 or len == 40 or len == 64 -%}
-              {%- unless seen contains node -%}
-                {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-                {%- assign sep = ',' -%}
-                {%- assign seen = seen | push: node -%}
-              {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
             {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- assign len = candidate | size -%}
+                {%- if len == 32 or len == 40 or len == 64 -%}
+                  {%- unless seen contains candidate -%}
+                    {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                    {%- assign sep = ',' -%}
+                    {%- assign seen = seen | push: candidate -%}
+                  {%- endunless -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.file_hash != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-ip-address-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-ip-address-relationships.yaml
@@ -192,11 +192,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.ip_address != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-ip-address-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-ip-address-relationships.yaml
@@ -1,0 +1,752 @@
+# Retrieves objects related to an IP address by relationship type (e.g.
+# communicating_files, resolutions, urls), paging until GTI has no more to
+# give, and indexes every related object as its own document. Writes one
+# summary note (one section per item) and an alert tag when run against an
+# alert. Manual only - no detection-rule trigger, since there's no
+# relationship worth choosing automatically on every alert.
+version: '1'
+name: GTI IP Address Relationships
+description: >-
+  Retrieve objects related to an IP address by relationship type (e.g.
+  communicating files, historical resolutions, hosted URLs), paging until GTI
+  has no more to give. Indexes every related object as its own document and
+  summarises the whole fetched batch on the triggering alert. Manual only;
+  not attached to a detection rule.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - ip-relationship
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-ip-relationship
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["source.ip", "destination.ip", "host.ip", "client.ip", "server.ip"]
+  gti_ui_base: https://www.virustotal.com/gui/ip-address
+  empty_arr: []
+  page_size: 40
+
+triggers:
+  - type: manual
+    inputs:
+      - name: ip_address
+        type: string
+        required: false
+        description: >-
+          IPv4 or IPv6 address, e.g. "8.8.8.8" or "2001:4860:4860::8888".
+          Leave blank when running against an alert, the address is read from
+          the alert instead.
+      # Safe to require: this workflow has no alert trigger, so there's no automatic
+      # run this could ever block.
+      - name: relationship
+        type: string
+        required: true
+        description: >-
+          Relationship to retrieve, e.g. "communicating_files",
+          "resolutions", or "urls". GTI validates this against its own
+          current set for IP objects and returns a 404 for a value it does
+          not recognize; the workflow surfaces that as a skipped address
+          rather than a failed run. Full current list:
+          https://gtidocs.virustotal.com/reference/ip-object#relationships
+      - name: limit
+        type: number
+        required: false
+        description: >-
+          Page size for each internal GTI fetch while paging (advanced,
+          rarely needed - defaults to 40, GTI's own maximum for this
+          endpoint). This does not cap the total number of items collected:
+          the workflow still pages until GTI reports no more, or the safety
+          backstop (250 pages, see the paginate step) is hit; it only changes
+          how many items are requested per underlying API call.
+      - name: cursor
+        type: string
+        required: false
+        description: >-
+          Continuation cursor from a previous standalone run's
+          pagination.next_cursor (only meaningful together with ip_address,
+          when a prior run hit the safety backstop below and left more items
+          unfetched). Ignored on every other run - an alert-attached run
+          always pages from the start.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write. ignore_malformed absorbs the number-vs-string
+  # collisions confirmed live across relationship object types (e.g.
+  # attributes.threat_severity.version); a harder object-vs-scalar collision
+  # would need mappings.properties.gti: {enabled:false} instead - not applied
+  # here since none has been observed in 18 of 22 relationship types checked.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_doc_link_base
+    type: data.set
+    with:
+      doc_link_base: |-
+        {%- if variables.data_view_id != blank -%}
+          {%- assign sp = '' -%}
+          {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+          {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.ip_address != blank -%}
+        {"field":"manual","value":"{{ inputs.ip_address | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable IP address found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the ip_address input. Nothing to look up.
+
+  - name: enrich_each_ip
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_iter
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+
+      - name: init_pagination
+        type: data.set
+        with:
+          note_sections: "${{ consts.empty_arr }}"
+          page_cursor: "{%- if variables.target_id == blank -%}{{ inputs.cursor }}{%- endif -%}"
+          has_more: true
+          collected: 0
+          any_success: false
+          fetch_incomplete: false
+
+      - name: paginate
+        type: while
+        condition: "${{ variables.has_more == true }}"
+        # Backstop only (GTI's own cursor going blank is the real stop condition), so a
+        # vendor-side cursor bug can't loop forever. `max-iterations` only accepts a literal
+        # number or {limit, on-limit} - not a template - so this can't be pulled from consts.
+        max-iterations: 250
+        steps:
+
+          - name: get_ip_relationship
+            type: google_threat_intelligence.getIpRelationship
+            connector-id: "{{ consts.gti_connector_id }}"
+            with:
+              ipAddress: "{{ variables.observable }}"
+              relationship: "{{ inputs.relationship }}"
+              limit: "${{ inputs.limit | default: consts.page_size }}"
+              cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              retry:
+                max-attempts: 2
+                delay: 3s
+              continue: true
+
+          - name: collect_page
+            type: if
+            condition: "${{ steps.get_ip_relationship.error == blank }}"
+            steps:
+              # Defensive: no current ip relationship type is single-object, but GTI could add one
+              - name: stash_page
+                type: if
+                condition: "${{ steps.get_ip_relationship.output.data.id != blank }}"
+                steps:
+                  - name: stash_single_item
+                    type: data.set
+                    with:
+                      page_items: "${{ consts.empty_arr | push: steps.get_ip_relationship.output.data }}"
+                      page_next_cursor: "{{ steps.get_ip_relationship.output.meta.cursor }}"
+                else:
+                  - name: stash_array_items
+                    type: data.set
+                    with:
+                      page_items: "${{ steps.get_ip_relationship.output.data | default: consts.empty_arr }}"
+                      page_next_cursor: "{{ steps.get_ip_relationship.output.meta.cursor }}"
+
+              - name: index_page_items
+                type: foreach
+                foreach: "${{ variables.page_items }}"
+                steps:
+                  - name: compute_item_doc_id
+                    type: data.set
+                    with:
+                      item_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-' | append: foreach.item.id | sha256 }}"
+
+                  - name: index_relationship_item
+                    type: elasticsearch.index
+                    with:
+                      index: "{{ consts.index }}"
+                      id: "{{ variables.item_doc_id }}"
+                      document:
+                        "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                        event:
+                          kind: enrichment
+                          category: threat
+                          dataset: gti_soar.ip_relationship
+                        observable:
+                          type: ip
+                          field: "{{ variables.field_name }}"
+                          value: "{{ variables.observable }}"
+                        relationship: "{{ inputs.relationship }}"
+                        trigger_mode: "{{ variables.trigger_mode }}"
+                        kibana:
+                          alert:
+                            uuid: "{{ variables.target_id }}"
+                            index: "{{ variables.target_index }}"
+                        rule:
+                          id: "{{ variables.rule_id }}"
+                          name: "{{ variables.rule_name }}"
+                        workflow:
+                          execution_id: "{{ execution.id }}"
+                        summary:
+                          related_object_id: "{{ foreach.item.id }}"
+                          related_object_type: "{{ foreach.item.type }}"
+                          reputation: "${{ foreach.item.attributes.reputation | plus: 0 }}"
+                          tags: "${{ foreach.item.attributes.tags | default: consts.empty_arr }}"
+                        gti: "${{ foreach.item }}"
+                    on-failure:
+                      continue: true
+
+                  # Type-aware per-item section - object types confirmed live:
+                  # resolution, file, url, vote, comment, collection, ssl_cert,
+                  # graph, whois. Any type not covered falls through to the
+                  # generic last_analysis_stats/reputation/tags fields below.
+                  - name: build_item_note_section
+                    type: data.set
+                    with:
+                      item_note_section: |-
+                        {%- assign a = foreach.item.attributes -%}
+                        {%- assign t = foreach.item.type -%}
+                        {%- assign stats = a.last_analysis_stats -%}
+                        {%- assign tags = a.tags | default: consts.empty_arr -%}
+                        ### {{ t }}: {{ foreach.item.id }}
+                        {%- case t %}
+                          {%- when 'resolution' %}
+                        {%- if a.host_name != blank %}
+                        - **Host name:** {{ a.host_name }}
+                        {%- endif %}
+                        {%- if a.date != blank %}
+                        - **Resolved:** {{ a.date | date: '%Y-%m-%d' }}{% if a.resolver != blank %} via {{ a.resolver }}{% endif %}
+                        {%- endif %}
+                          {%- when 'file' %}
+                        {%- assign fname = a.meaningful_name | default: a.names[0] -%}
+                        {%- if fname != blank %}
+                        - **Name:** {{ fname }}
+                        {%- endif %}
+                        {%- if a.type_description != blank or a.size != blank %}
+                        - **Type:** {% if a.type_description != blank %}{{ a.type_description }}{% endif %}{% if a.size != blank %}, {{ a.size }} bytes{% endif %}
+                        {%- endif %}
+                        {%- if a.first_submission_date != blank %}
+                        - **First submitted:** {{ a.first_submission_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'url' %}
+                        {%- if a.title != blank %}
+                        - **Title:** {{ a.title }}
+                        {%- endif %}
+                        {%- if a.last_final_url != blank %}
+                        - **Final URL:** {{ a.last_final_url }}
+                        {%- endif %}
+                        {%- if a.threat_names.size > 0 %}
+                        - **Threat names:** {{ a.threat_names | join: ', ' }}
+                        {%- endif %}
+                          {%- when 'vote' %}
+                        - **Verdict:** {{ a.verdict }}{% if a.value != blank %} (value {{ a.value }}){% endif %}
+                        {%- if a.date != blank %}
+                        - **Date:** {{ a.date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'comment' %}
+                        {%- assign comment_line = a.text | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                        - **Comment:** {{ comment_line }}
+                          {%- when 'collection' %}
+                        {%- if a.name != blank %}
+                        - **Name:** {{ a.name }}
+                        {%- endif %}
+                        {%- if a.collection_type != blank %}
+                        - **Type:** {{ a.collection_type }}
+                        {%- endif %}
+                        {%- assign summary_raw = a.executive_summary | default: a.analyst_comment | default: a.description -%}
+                        {%- if summary_raw != blank %}
+                        {%- assign summary_line = summary_raw | strip_html | replace: '\n', ' ' | replace: '  ', ' ' | strip | truncate: 400 %}
+                        - **Summary:** {{ summary_line }}
+                        {%- endif %}
+                          {%- when 'ssl_cert' %}
+                        {%- if a.subject.CN != blank or a.issuer.CN != blank %}
+                        - **Certificate:** {% if a.subject.CN != blank %}CN={{ a.subject.CN }}{% endif %}{% if a.issuer.CN != blank %}, issued by {{ a.issuer.CN }}{% endif %}
+                        {%- endif %}
+                        {%- if a.validity.not_before != blank or a.validity.not_after != blank %}
+                        - **Valid:** {{ a.validity.not_before }} to {{ a.validity.not_after }}
+                        {%- endif %}
+                          {%- when 'graph' %}
+                        {%- if a.graph_data.description != blank %}
+                        - **Description:** {{ a.graph_data.description }}
+                        {%- endif %}
+                        {%- if a.nodes.size > 0 %}
+                        - **Nodes:** {{ a.nodes.size }}
+                        {%- endif %}
+                        {%- if a.creation_date != blank %}
+                        - **Created:** {{ a.creation_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- if a.views_count != blank or a.comments_count != blank %}
+                        - **Activity:** {{ a.views_count | default: 0 }} view(s), {{ a.comments_count | default: 0 }} comment(s)
+                        {%- endif %}
+                          {%- when 'whois' %}
+                        {%- if a.first_seen_date != blank %}
+                        - **First seen:** {{ a.first_seen_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- assign whois_pairs = a.whois_map | entries -%}
+                        {%- if whois_pairs.size > 0 %}
+                        - **WHOIS fields:**
+                        {%- for pair in whois_pairs limit: 10 %}
+                          - {{ pair.key }}: {{ pair.value }}
+                        {%- endfor %}
+                        {%- if whois_pairs.size > 10 %}
+                          - _(and {{ whois_pairs.size | minus: 10 }} more - see the full document)_
+                        {%- endif %}
+                        {%- endif %}
+                        {%- endcase %}
+                        {%- if stats != blank %}
+                        - **Last analysis:** {{ stats.malicious | default: 0 }} malicious, {{ stats.suspicious | default: 0 }} suspicious, {{ stats.harmless | default: 0 }} harmless, {{ stats.undetected | default: 0 }} undetected
+                        {%- endif %}
+                        {%- if a.reputation != blank %}
+                        - **Reputation:** {{ a.reputation }}
+                        {%- endif %}
+                        {%- if tags.size > 0 %}
+                        - **Tags:** {{ tags | join: ', ' }}
+                        {%- endif %}
+                        {% if steps.index_relationship_item.error != blank %}_Not indexed: this item's response could not be stored (see the workflow's execution log for detail)._{% elsif variables.doc_link_base != blank %}[Open {{ t }} document in Discover](<{{ variables.doc_link_base }}?id={{ variables.item_doc_id }}>){% else %}Full document in index `{{ consts.index }}`, document
+                        ```
+                        {{ variables.item_doc_id }}
+                        ```
+                        {% endif %}
+
+                  - name: wrap_note_section
+                    type: data.set
+                    with:
+                      item_note_section_arr: "${{ variables.item_note_section | split: '@@GTI_NOTE_SEP@@' }}"
+
+                  - name: accumulate_note_section
+                    type: data.set
+                    with:
+                      note_sections: "${{ variables.note_sections | concat: variables.item_note_section_arr }}"
+
+              - name: advance_cursor
+                type: data.set
+                with:
+                  any_success: true
+                  page_cursor: "{{ variables.page_next_cursor }}"
+                  collected: "${{ variables.collected | plus: variables.page_items.size }}"
+              - name: eval_has_more
+                type: data.set
+                with:
+                  has_more: "${{ variables.page_next_cursor != blank }}"
+
+          - name: handle_page_error
+            type: if
+            condition: "${{ steps.get_ip_relationship.error != blank }}"
+            steps:
+              - name: stop_on_error
+                type: data.set
+                with:
+                  has_more: false
+                  fetch_incomplete: true
+                  fetch_error: "${{ steps.get_ip_relationship.error }}"
+
+      - name: compute_truncated
+        type: data.set
+        with:
+          truncated: "${{ variables.has_more == true }}"
+
+      - name: compute_run_status
+        type: data.set
+        with:
+          run_status: "{% if variables.any_success != true %}failed{% elsif variables.fetch_incomplete == true or variables.truncated == true %}partial{% else %}succeeded{% endif %}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-run-summary' | sha256 }}"
+
+      - name: write_run_summary
+        type: if
+        condition: "${{ variables.run_status != 'succeeded' }}"
+        steps:
+          - name: index_run_summary
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.ip_relationship
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ variables.fetch_error.message }}"
+                  type: "{{ variables.fetch_error.type }}"
+                observable:
+                  type: ip
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                relationship: "{{ inputs.relationship }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                pagination:
+                  collected: "${{ variables.collected }}"
+                  fetch_incomplete: "${{ variables.fetch_incomplete }}"
+                  truncated: "${{ variables.truncated }}"
+                  next_cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              continue: true
+
+      - name: skip_on_total_failure
+        type: if
+        condition: "${{ variables.any_success != true }}"
+        steps:
+          - name: log_fetch_failure
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getIpRelationship failed for {{ variables.field_name }} ({{ variables.observable }}), relationship {{ inputs.relationship }}.
+                {{ variables.fetch_error | json }}
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI IP Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI IP Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                    _Managed by the GTI IP Address Relationships workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View IP on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve any data from GTI.
+                    > `{{ variables.fetch_error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: skip_when_empty
+        type: if
+        condition: "${{ variables.collected == 0 }}"
+        steps:
+          - name: log_empty
+            type: console
+            with:
+              message: >-
+                GTI has no {{ inputs.relationship }} relationship data for {{ variables.observable }}.
+                Nothing written.
+          - name: skip_empty_iteration
+            type: loop.continue
+
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and variables.collected > 0 }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI IP Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI IP Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                _Managed by the GTI IP Address Relationships workflow. This note is replaced on every run and describes only what this run fetched; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View IP on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                **STATUS: {{ variables.run_status }}.** {{ variables.collected }} {{ inputs.relationship }} object(s) retrieved.
+
+                {%- if variables.fetch_incomplete %}
+
+                > **Incomplete:** retrieval stopped early because a GTI API request failed; results below may be missing further items.
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+
+                > **Unexpectedly large result set:** stopped after {{ variables.collected }} items as a safety limit; GTI still had more to page through. Re-run standalone with `cursor: {{ variables.page_cursor }}` to continue.
+                {%- endif %}
+
+                {%- for section in variables.note_sections %}
+                {{ section }}
+                {% endfor %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:ip-relationship"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank and variables.collected > 0 }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: {{ variables.run_status }} - GTI IP relationship {{ inputs.relationship }} for {{ variables.observable }}: {{ variables.collected }} object(s) retrieved.
+                {%- if variables.fetch_incomplete %}
+                (retrieval stopped early due to a GTI API error; results may be incomplete)
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+                (safety limit reached after {{ variables.collected }} items; GTI still had more - re-run with cursor: {{ variables.page_cursor }} to continue)
+                {%- endif %}
+                Indexed to {{ consts.index }}, one document per related object.

--- a/examples/integrations/google-threat-intelligence/gti-ip-address-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-ip-address-report.yaml
@@ -145,11 +145,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.ip_address != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-ip-address-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-ip-address-report.yaml
@@ -1,0 +1,559 @@
+# Retrieves the GTI reputation and detection report for an IP address and
+# indexes the full response. When run against an alert (paths 1/2) it also
+# writes a summary note and an alert tag; a standalone run (path 3) only
+# indexes. getIpReport takes no limit/cursor - a single-object report, not
+# paginated.
+version: '1'
+name: GTI IP Address Report
+description: >-
+  Retrieve the Google Threat Intelligence reputation and detection report for
+  an IP address. Indexes the full response and summarises it on the
+  triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - ip-report
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-ip-report
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["source.ip", "destination.ip", "host.ip", "client.ip", "server.ip"]
+  gti_ui_base: https://www.virustotal.com/gui/ip-address
+  empty_arr: []
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: ip_address
+        type: string
+        required: false
+        description: >-
+          IPv4 or IPv6 address, e.g. "8.8.8.8" or "2001:4860:4860::8888".
+          Leave blank when running against an alert, the address is read from
+          the alert instead.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.ip_address != blank -%}
+        {"field":"manual","value":"{{ inputs.ip_address | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable IP address found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the ip_address input. Nothing to look up.
+
+  - name: enrich_each_ip
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_observable
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | append: '-run-summary' | sha256 }}"
+
+      - name: get_ip_report
+        type: google_threat_intelligence.getIpReport
+        connector-id: "{{ consts.gti_connector_id }}"
+        with:
+          ipAddress: "{{ foreach.item.value }}"
+        on-failure:
+          retry:
+            max-attempts: 2
+            delay: 3s
+          continue: true
+
+      - name: skip_on_fetch_error
+        type: if
+        condition: "${{ steps.get_ip_report.error != blank }}"
+        steps:
+          - name: log_fetch_error
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getIpReport failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ steps.get_ip_report.error | json }}
+
+          - name: write_fetch_failure
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.ip_report
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ steps.get_ip_report.error.message }}"
+                  type: "{{ steps.get_ip_report.error.type }}"
+                observable:
+                  type: ip
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+            on-failure:
+              continue: true
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI IP Report: ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI IP Report: {{ variables.observable }}
+
+                    _Managed by the GTI IP Address Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View IP on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve data from GTI.
+                    > `{{ steps.get_ip_report.error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: stash_iter
+        type: data.set
+        with:
+          attrs: "${{ steps.get_ip_report.output.data.attributes }}"
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+
+      - name: summarise
+        type: data.set
+        with:
+          verdict: "{{ variables.attrs.gti_assessment.verdict.value | default: 'UNKNOWN' }}"
+          severity: "{{ variables.attrs.gti_assessment.severity.value | default: 'UNKNOWN' }}"
+          threat_score: "{{ variables.attrs.gti_assessment.threat_score.value | default: 0 }}"
+          description: "{{ variables.attrs.gti_assessment.description | replace: '\n', ' ' | replace: '  ', ' ' | strip }}"
+          malicious_count: "{{ variables.attrs.last_analysis_stats.malicious | default: 0 }}"
+          suspicious_count: "{{ variables.attrs.last_analysis_stats.suspicious | default: 0 }}"
+          harmless_count: "{{ variables.attrs.last_analysis_stats.harmless | default: 0 }}"
+          undetected_count: "{{ variables.attrs.last_analysis_stats.undetected | default: 0 }}"
+          last_analysis_date: "{{ variables.attrs.last_analysis_date }}"
+          reputation: "{{ variables.attrs.reputation | default: 0 }}"
+          votes_harmless: "{{ variables.attrs.total_votes.harmless | default: 0 }}"
+          votes_malicious: "{{ variables.attrs.total_votes.malicious | default: 0 }}"
+          as_owner: "{{ variables.attrs.as_owner }}"
+          asn: "{{ variables.attrs.asn }}"
+          network: "{{ variables.attrs.network }}"
+          country: "{{ variables.attrs.country }}"
+          continent: "{{ variables.attrs.continent }}"
+          rir: "{{ variables.attrs.regional_internet_registry }}"
+          tags: "${{ variables.attrs.tags }}"
+          crowdsourced_context: "${{ variables.attrs.crowdsourced_context | default: consts.empty_arr }}"
+
+      - name: index_enrichment
+        type: elasticsearch.index
+        with:
+          index: "{{ consts.index }}"
+          id: "{{ variables.doc_id }}"
+          document:
+            "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+            event:
+              kind: enrichment
+              category: threat
+              dataset: gti_soar.ip_report
+            observable:
+              type: ip
+              field: "{{ variables.field_name }}"
+              value: "{{ variables.observable }}"
+            trigger_mode: "{{ variables.trigger_mode }}"
+            kibana:
+              alert:
+                uuid: "{{ variables.target_id }}"
+                index: "{{ variables.target_index }}"
+            rule:
+              id: "{{ variables.rule_id }}"
+              name: "{{ variables.rule_name }}"
+            workflow:
+              execution_id: "{{ execution.id }}"
+            summary:
+              verdict: "{{ variables.verdict }}"
+              severity: "{{ variables.severity }}"
+              description: "{{ variables.description }}"
+              threat_score: "${{ variables.threat_score | plus: 0 }}"
+              malicious_count: "${{ variables.malicious_count | plus: 0 }}"
+              suspicious_count: "${{ variables.suspicious_count | plus: 0 }}"
+              harmless_count: "${{ variables.harmless_count | plus: 0 }}"
+              undetected_count: "${{ variables.undetected_count | plus: 0 }}"
+              last_analysis_date: "{{ variables.last_analysis_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+              reputation: "${{ variables.reputation | plus: 0 }}"
+              votes_harmless: "${{ variables.votes_harmless | plus: 0 }}"
+              votes_malicious: "${{ variables.votes_malicious | plus: 0 }}"
+              as_owner: "{{ variables.as_owner }}"
+              asn: "{{ variables.asn }}"
+              network: "{{ variables.network }}"
+              country: "{{ variables.country }}"
+              continent: "{{ variables.continent }}"
+              regional_internet_registry: "{{ variables.rir }}"
+              tags: "${{ variables.tags }}"
+              crowdsourced_context: "${{ variables.crowdsourced_context }}"
+            gti: "${{ steps.get_ip_report.output.data }}"
+        on-failure:
+          continue: true
+
+      # Paths 1/2 only, and only once the document actually exists.
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and steps.index_enrichment.error == blank }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: build_doc_link
+            type: data.set
+            with:
+              doc_link: |-
+                {%- if variables.data_view_id != blank -%}
+                  {%- assign sp = '' -%}
+                  {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                  {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.doc_id }}
+                {%- endif -%}
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI IP Report: ' | append: variables.observable -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI IP Report: {{ variables.observable }}
+
+                _Managed by the GTI IP Address Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View IP on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                ### Assessment
+                - **Verdict:** {{ variables.verdict }}
+                - **Severity:** {{ variables.severity }}
+                - **Threat score:** {{ variables.threat_score }}
+                - **Reputation:** {{ variables.reputation }}
+                {%- if variables.description != blank %}
+                - **GTI summary:** {{ variables.description }}
+                {%- endif %}
+
+                ### Detection
+                - **Last analysis:** {{ variables.malicious_count }} malicious, {{ variables.suspicious_count }} suspicious, {{ variables.harmless_count }} harmless, {{ variables.undetected_count }} undetected{% if variables.last_analysis_date != blank %} (as of {{ variables.last_analysis_date | date: '%Y-%m-%d' }}){% endif %}
+                {%- if variables.votes_harmless != blank or variables.votes_malicious != blank %}
+                - **Community votes:** {{ variables.votes_harmless | default: 0 }} harmless, {{ variables.votes_malicious | default: 0 }} malicious
+                {%- endif %}
+                {%- if variables.as_owner != blank or variables.asn != blank or variables.network != blank or variables.country != blank or variables.continent != blank %}
+
+                ### Network & location
+                {%- if variables.as_owner != blank or variables.asn != blank or variables.network != blank %}
+                - **Network:** {% if variables.as_owner != blank %}{{ variables.as_owner }}{% endif %}{% if variables.asn != blank %} (AS{{ variables.asn }}){% endif %}{% if variables.network != blank %}, {{ variables.network }}{% endif %}
+                {%- endif %}
+                {%- if variables.country != blank or variables.continent != blank %}
+                - **Geolocation:** {% if variables.country != blank %}{{ variables.country }}{% endif %}{% if variables.continent != blank %}, {{ variables.continent }}{% endif %}{% if variables.rir != blank %} ({{ variables.rir }}){% endif %}
+                {%- endif %}
+                {%- endif %}
+                {%- if variables.tags.size > 0 %}
+
+                ### Tags
+                - {{ variables.tags | join: ', ' }}
+                {%- endif %}
+                {%- if variables.crowdsourced_context.size > 0 %}
+
+                ### Community context
+                {%- for c in variables.crowdsourced_context %}
+                {%- assign detail_line = c.details | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                - **{{ c.title }}** ({{ c.severity | default: 'unknown' }} severity, via {{ c.source }}){% if c.timestamp != blank %}, {{ c.timestamp | date: '%Y-%m-%d' }}{% endif %}: {{ detail_line }}
+                {%- endfor %}
+                {%- endif %}
+
+                ---
+                {% if variables.doc_link != blank %}Full response: [open the stored document in Discover](<{{ variables.doc_link }}>){% else %}Full response in index `{{ consts.index }}`, document
+                ```
+                {{ variables.doc_id }}
+                ```
+                {% endif %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:ip-report"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: succeeded - GTI IP report for {{ variables.observable }}: verdict {{ variables.verdict }}, severity {{ variables.severity }}.
+                Indexed to {{ consts.index }} / {{ variables.doc_id }}

--- a/examples/integrations/google-threat-intelligence/gti-mitre-attack-techniques.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-mitre-attack-techniques.yaml
@@ -1,0 +1,548 @@
+# Retrieves the MITRE ATT&CK tactics/techniques GTI observed for a file hash
+# across its sandboxes and indexes the full response. When run against an
+# alert (paths 1/2) it also writes a summary note and an alert tag; a
+# standalone run (path 3) only indexes.
+version: '1'
+name: GTI MITRE ATT&CK Techniques
+description: >-
+  Retrieve the MITRE ATT&CK tactics and techniques Google Threat Intelligence
+  observed for a file hash, grouped by sandbox. Indexes the full response and
+  summarises it on the triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - mitre-attack
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-mitre-attack
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["file.hash.sha256", "process.hash.sha256", "dll.hash.sha256"]
+  gti_ui_base: https://www.virustotal.com/gui/file
+  empty_arr: []
+  # Documented value set is HIGH/MEDIUM/LOW/INFO/UNKNOWN; the ordering itself
+  # is a local choice (UNKNOWN ranked lowest - no severity assigned, not benign).
+  severity_rank: "UNKNOWN,INFO,LOW,MEDIUM,HIGH"
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: file_hash
+        type: string
+        required: false
+        description: >-
+          SHA-256, SHA-1 or MD5 hash. Leave blank when running against an alert,
+          the hash is read from the alert instead.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  # Length check because the connector validates fileHash against a SHA-256/1/MD5 regex.
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- assign len = node | size -%}
+            {%- if len == 32 or len == 40 or len == 64 -%}
+              {%- unless seen contains node -%}
+                {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+                {%- assign sep = ',' -%}
+                {%- assign seen = seen | push: node -%}
+              {%- endunless -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.file_hash != blank -%}
+        {"field":"manual","value":"{{ inputs.file_hash | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable file hash found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the file_hash input. Nothing to look up.
+
+  - name: enrich_each_hash
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_observable
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | append: '-run-summary' | sha256 }}"
+
+      - name: get_mitre_techniques
+        type: google_threat_intelligence.getFileMitreAttackTechniques
+        connector-id: "{{ consts.gti_connector_id }}"
+        with:
+          fileHash: "{{ foreach.item.value }}"
+        on-failure:
+          retry:
+            max-attempts: 2
+            delay: 3s
+          continue: true
+
+      - name: skip_on_fetch_error
+        type: if
+        condition: "${{ steps.get_mitre_techniques.error != blank }}"
+        steps:
+          - name: log_fetch_error
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getFileMitreAttackTechniques failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ steps.get_mitre_techniques.error | json }}
+
+          - name: write_fetch_failure
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.mitre_attack
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ steps.get_mitre_techniques.error.message }}"
+                  type: "{{ steps.get_mitre_techniques.error.type }}"
+                observable:
+                  type: file_hash
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+            on-failure:
+              continue: true
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI ATT&CK: ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI ATT&CK: {{ variables.observable }}
+
+                    _Managed by the GTI MITRE ATT&CK workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View file on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve data from GTI.
+                    > `{{ steps.get_mitre_techniques.error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      # Response has no attributes wrapper - data is keyed directly by sandbox
+      # name, so a Liquid loop yields [name, tree] pairs.
+      - name: stash_iter
+        type: data.set
+        with:
+          mitre: "${{ steps.get_mitre_techniques.output.data }}"
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+
+      - name: summarise
+        type: data.set
+        with:
+          sandbox_count: "{%- assign n = 0 -%}{%- for s in variables.mitre -%}{%- assign n = n | plus: 1 -%}{%- endfor -%}{{ n }}"
+          # Distinct counts - the same technique routinely appears under several tactics/sandboxes.
+          tactic_count: |-
+            {%- assign seen = consts.empty_arr -%}{%- assign n = 0 -%}
+            {%- for s in variables.mitre -%}{%- for t in s[1].tactics -%}
+              {%- unless seen contains t.id -%}{%- assign n = n | plus: 1 -%}{%- assign seen = seen | push: t.id -%}{%- endunless -%}
+            {%- endfor -%}{%- endfor -%}{{ n }}
+          technique_count: |-
+            {%- assign seen = consts.empty_arr -%}{%- assign n = 0 -%}
+            {%- for s in variables.mitre -%}{%- for t in s[1].tactics -%}{%- for tech in t.techniques -%}
+              {%- unless seen contains tech.id -%}{%- assign n = n | plus: 1 -%}{%- assign seen = seen | push: tech.id -%}{%- endunless -%}
+            {%- endfor -%}{%- endfor -%}{%- endfor -%}{{ n }}
+          technique_occurrences: "{%- assign n = 0 -%}{%- for s in variables.mitre -%}{%- for t in s[1].tactics -%}{%- assign n = n | plus: t.techniques.size -%}{%- endfor -%}{%- endfor -%}{{ n }}"
+          technique_ids: |-
+            {%- assign seen = consts.empty_arr -%}{%- assign sep = '' -%}
+            {%- for s in variables.mitre -%}{%- for t in s[1].tactics -%}{%- for tech in t.techniques -%}
+              {%- unless seen contains tech.id -%}
+                {{ sep }}{{ tech.id }}{%- assign sep = ', ' -%}{%- assign seen = seen | push: tech.id -%}
+              {%- endunless -%}
+            {%- endfor -%}{%- endfor -%}{%- endfor -%}
+          # Highest signature severity anywhere in the tree, by consts.severity_rank.
+          max_severity: |-
+            {%- assign order = consts.severity_rank | split: ',' -%}{%- assign maxi = 0 -%}
+            {%- for s in variables.mitre -%}{%- for t in s[1].tactics -%}{%- for tech in t.techniques -%}
+              {%- for sig in tech.signatures -%}
+                {%- for o in order -%}
+                  {%- if o == sig.severity and forloop.index0 > maxi -%}{%- assign maxi = forloop.index0 -%}{%- endif -%}
+                {%- endfor -%}
+              {%- endfor -%}
+            {%- endfor -%}{%- endfor -%}{%- endfor -%}
+            {%- assign resolved_severity = order[maxi] -%}
+            {{ resolved_severity }}
+
+      - name: skip_when_empty
+        type: if
+        condition: "${{ variables.technique_count == '0' }}"
+        steps:
+          - name: log_empty
+            type: console
+            with:
+              message: >-
+                GTI has no ATT&CK tree for {{ variables.observable }}; the file
+                is known but has not been detonated. Nothing written.
+          - name: skip_empty_iteration
+            type: loop.continue
+
+      - name: index_enrichment
+        type: elasticsearch.index
+        with:
+          index: "{{ consts.index }}"
+          id: "{{ variables.doc_id }}"
+          document:
+            "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+            event:
+              kind: enrichment
+              category: threat
+              dataset: gti_soar.mitre_attack
+            observable:
+              type: file_hash
+              field: "{{ variables.field_name }}"
+              value: "{{ variables.observable }}"
+            trigger_mode: "{{ variables.trigger_mode }}"
+            kibana:
+              alert:
+                uuid: "{{ variables.target_id }}"
+                index: "{{ variables.target_index }}"
+            rule:
+              id: "{{ variables.rule_id }}"
+              name: "{{ variables.rule_name }}"
+            workflow:
+              execution_id: "{{ execution.id }}"
+            summary:
+              sandbox_count: "${{ variables.sandbox_count | plus: 0 }}"
+              tactic_count: "${{ variables.tactic_count | plus: 0 }}"
+              technique_count: "${{ variables.technique_count | plus: 0 }}"
+              technique_occurrences: "${{ variables.technique_occurrences | plus: 0 }}"
+              max_severity: "{{ variables.max_severity }}"
+              technique_ids: "{{ variables.technique_ids }}"
+            gti: "${{ steps.get_mitre_techniques.output.data }}"
+        on-failure:
+          continue: true
+
+      # Paths 1/2 only, and only once the document actually exists.
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and steps.index_enrichment.error == blank }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: build_doc_link
+            type: data.set
+            with:
+              doc_link: |-
+                {%- if variables.data_view_id != blank -%}
+                  {%- assign sp = '' -%}
+                  {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                  {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.doc_id }}
+                {%- endif -%}
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI ATT&CK: ' | append: variables.observable -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI ATT&CK: {{ variables.observable }}
+
+                _Managed by the GTI MITRE ATT&CK workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View file on GTI]({{ consts.gti_ui_base }}/{{ variables.observable }})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                **{{ variables.technique_count }} unique technique(s) across {{ variables.tactic_count }} tactic(s), observed in {{ variables.sandbox_count }} sandbox(es). Highest signature severity {{ variables.max_severity }}.**
+
+                {% for sandbox in variables.mitre %}### Sandbox: {{ sandbox[0] }}
+
+                {% for tactic in sandbox[1].tactics %}**[{{ tactic.name }}]({{ tactic.link }})** `{{ tactic.id }}`
+                {% for technique in tactic.techniques %}{%- assign order = consts.severity_rank | split: ',' -%}{%- assign sigs = technique.signatures | default: consts.empty_arr -%}{%- assign maxi = 0 -%}{%- for sig in sigs -%}{%- for o in order -%}{%- if o == sig.severity and forloop.index0 > maxi -%}{%- assign maxi = forloop.index0 -%}{%- endif -%}{%- endfor -%}{%- endfor -%}- [{{ technique.name }}]({{ technique.link }}) `{{ technique.id }}`{% assign resolved_severity = order[maxi] %} - {% if sigs.size > 0 %}{{ sigs.size }} signature(s), highest severity **{{ resolved_severity }}**{% else %}no signatures{% endif %}
+                {% endfor %}
+                {% endfor %}
+                {% endfor %}
+                ---
+                {% if variables.doc_link != blank %}Full response: [open the stored document in Discover](<{{ variables.doc_link }}>){% else %}Full response in index `{{ consts.index }}`, document
+                ```
+                {{ variables.doc_id }}
+                ```
+                {% endif %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:mitre-attack"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: succeeded - GTI ATT&CK for {{ variables.observable }}: {{ variables.technique_count }} technique(s) across {{ variables.sandbox_count }} sandbox(es).
+                Indexed to {{ consts.index }} / {{ variables.doc_id }}

--- a/examples/integrations/google-threat-intelligence/gti-mitre-attack-techniques.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-mitre-attack-techniques.yaml
@@ -147,14 +147,24 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- assign len = node | size -%}
-            {%- if len == 32 or len == 40 or len == 64 -%}
-              {%- unless seen contains node -%}
-                {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-                {%- assign sep = ',' -%}
-                {%- assign seen = seen | push: node -%}
-              {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
             {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- assign len = candidate | size -%}
+                {%- if len == 32 or len == 40 or len == 64 -%}
+                  {%- unless seen contains candidate -%}
+                    {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                    {%- assign sep = ',' -%}
+                    {%- assign seen = seen | push: candidate -%}
+                  {%- endunless -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.file_hash != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-url-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-url-relationships.yaml
@@ -1,0 +1,793 @@
+# Retrieves objects related to a URL by relationship type (e.g. redirects,
+# contacted domains, downloaded files - 31 values), paging until GTI has no
+# more to give, and indexes every related object as its own document. Writes
+# one summary note (one section per item) and an alert tag when run against
+# an alert. Manual only, same reasoning as GTI IP Address Relationships.
+version: '1'
+name: GTI URL Relationships
+description: >-
+  Retrieve objects related to a URL by relationship type (e.g. redirects,
+  contacted domains, downloaded files), paging until GTI has no more to
+  give. Indexes every related object as its own document and summarises the
+  whole fetched batch on the triggering alert. Manual only; not attached to
+  a detection rule.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - url-relationship
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-url-relationship
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["url.full", "url.original"]
+  gti_ui_base: https://www.virustotal.com/gui/url
+  empty_arr: []
+  page_size: 40
+
+triggers:
+  - type: manual
+    inputs:
+      - name: url
+        type: string
+        required: false
+        description: >-
+          URL in its natural form, e.g. "https://example.com/path". Leave
+          blank when running against an alert, the URL is read from the
+          alert instead.
+      # Safe to require: this workflow has no alert trigger, so there's no automatic
+      # run this could ever block.
+      - name: relationship
+        type: string
+        required: true
+        description: >-
+          Relationship to retrieve, e.g. "redirects_to",
+          "contacted_domains", or "downloaded_files". GTI validates this
+          against its own current set for URL objects and returns a 404 for
+          a value it does not recognize; the workflow surfaces that as a
+          skipped URL rather than a failed run. Full current list:
+          https://gtidocs.virustotal.com/reference/url-object#relationships
+      - name: limit
+        type: number
+        required: false
+        description: >-
+          Page size for each internal GTI fetch while paging (advanced,
+          rarely needed - defaults to 40, GTI's own maximum for this
+          endpoint). This does not cap the total number of items collected:
+          the workflow still pages until GTI reports no more, or the safety
+          backstop (250 pages, see the paginate step) is hit; it only changes
+          how many items are requested per underlying API call.
+      - name: cursor
+        type: string
+        required: false
+        description: >-
+          Continuation cursor from a previous standalone run's
+          pagination.next_cursor (only meaningful together with url, when a
+          prior run hit the safety backstop below and left more items
+          unfetched). Ignored on every other run - an alert-attached run
+          always pages from the start.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write. Same reasoning and settings as
+  # gti-ip-address-relationships.yaml's bootstrap_index_template step.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_doc_link_base
+    type: data.set
+    with:
+      doc_link_base: |-
+        {%- if variables.data_view_id != blank -%}
+          {%- assign sp = '' -%}
+          {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+          {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.url != blank -%}
+        {"field":"manual","value":"{{ inputs.url | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable URL found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the url input. Nothing to look up.
+
+  - name: enrich_each_url
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_iter
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+
+      # Best-effort mirror of GTI's own "bare host -> host/" id normalization, since this workflow has no real id to use instead.
+      - name: canonicalize_url
+        type: data.set
+        with:
+          canonical_url: |-
+            {%- assign u = variables.observable -%}
+            {%- assign parts = u | split: '://' -%}
+            {%- if parts.size == 2 -%}
+              {%- unless parts[1] contains '/' -%}
+                {%- assign u = u | append: '/' -%}
+              {%- endunless -%}
+            {%- endif -%}
+            {{ u }}
+
+      - name: init_pagination
+        type: data.set
+        with:
+          note_sections: "${{ consts.empty_arr }}"
+          page_cursor: "{%- if variables.target_id == blank -%}{{ inputs.cursor }}{%- endif -%}"
+          has_more: true
+          collected: 0
+          any_success: false
+          fetch_incomplete: false
+
+      - name: paginate
+        type: while
+        condition: "${{ variables.has_more == true }}"
+        # Backstop only (GTI's own cursor going blank is the real stop condition), so a
+        # vendor-side cursor bug can't loop forever. `max-iterations` only accepts a literal
+        # number or {limit, on-limit} - not a template - so this can't be pulled from consts.
+        max-iterations: 250
+        steps:
+
+          - name: get_url_relationship
+            type: google_threat_intelligence.getUrlRelationship
+            connector-id: "{{ consts.gti_connector_id }}"
+            with:
+              url: "{{ variables.observable }}"
+              relationship: "{{ inputs.relationship }}"
+              limit: "${{ inputs.limit | default: consts.page_size }}"
+              cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              retry:
+                max-attempts: 2
+                delay: 3s
+              continue: true
+
+          - name: collect_page
+            type: if
+            condition: "${{ steps.get_url_relationship.error == blank }}"
+            steps:
+              # links.self embeds GTI's own canonical id for the queried URL (e.g. ".../urls/<id>/redirects_to?..."), same id gti-url-report.yaml/gti-url-scan-public.yaml get from their own responses - no extra call needed.
+              - name: stash_real_url_id
+                type: data.set
+                with:
+                  real_url_id: |-
+                    {%- assign after = steps.get_url_relationship.output.links.self | split: '/urls/' -%}
+                    {%- if after.size == 2 -%}{{ after[1] | split: '/' | first }}{%- endif -%}
+
+              # last_serving_ip_address and network_location return a single object rather than an array
+              - name: stash_page
+                type: if
+                condition: "${{ steps.get_url_relationship.output.data.id != blank }}"
+                steps:
+                  - name: stash_single_item
+                    type: data.set
+                    with:
+                      page_items: "${{ consts.empty_arr | push: steps.get_url_relationship.output.data }}"
+                      page_next_cursor: "{{ steps.get_url_relationship.output.meta.cursor }}"
+                else:
+                  - name: stash_array_items
+                    type: data.set
+                    with:
+                      page_items: "${{ steps.get_url_relationship.output.data | default: consts.empty_arr }}"
+                      page_next_cursor: "{{ steps.get_url_relationship.output.meta.cursor }}"
+
+              - name: index_page_items
+                type: foreach
+                foreach: "${{ variables.page_items }}"
+                steps:
+                  - name: compute_item_doc_id
+                    type: data.set
+                    with:
+                      item_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-' | append: foreach.item.id | sha256 }}"
+
+                  - name: index_relationship_item
+                    type: elasticsearch.index
+                    with:
+                      index: "{{ consts.index }}"
+                      id: "{{ variables.item_doc_id }}"
+                      document:
+                        "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                        event:
+                          kind: enrichment
+                          category: threat
+                          dataset: gti_soar.url_relationship
+                        observable:
+                          type: url
+                          field: "{{ variables.field_name }}"
+                          value: "{{ variables.observable }}"
+                        relationship: "{{ inputs.relationship }}"
+                        trigger_mode: "{{ variables.trigger_mode }}"
+                        kibana:
+                          alert:
+                            uuid: "{{ variables.target_id }}"
+                            index: "{{ variables.target_index }}"
+                        rule:
+                          id: "{{ variables.rule_id }}"
+                          name: "{{ variables.rule_name }}"
+                        workflow:
+                          execution_id: "{{ execution.id }}"
+                        summary:
+                          related_object_id: "{{ foreach.item.id }}"
+                          related_object_type: "{{ foreach.item.type }}"
+                          reputation: "${{ foreach.item.attributes.reputation | plus: 0 }}"
+                          tags: "${{ foreach.item.attributes.tags | default: consts.empty_arr }}"
+                        gti: "${{ foreach.item }}"
+                    on-failure:
+                      continue: true
+
+                  # Type-aware per-item section - reuses every case already
+                  # built across the other three relationship workflows;
+                  # this action introduces no new object type. Any type not
+                  # covered (submission - not confirmed populated on any URL
+                  # tried) falls through to the generic fields below.
+                  - name: build_item_note_section
+                    type: data.set
+                    with:
+                      item_note_section: |-
+                        {%- assign a = foreach.item.attributes -%}
+                        {%- assign t = foreach.item.type -%}
+                        {%- assign stats = a.last_analysis_stats | default: a.stats -%}
+                        {%- assign tags = a.tags | default: consts.empty_arr -%}
+                        ### {{ t }}: {{ foreach.item.id }}
+                        {%- case t %}
+                          {%- when 'url_analysis' %}
+                        {%- assign cat_pairs = a.categories | entries -%}
+                        {%- if cat_pairs.size > 0 %}
+                        - **Categories:** {% for pair in cat_pairs limit: 5 %}{{ pair.value }} ({{ pair.key }}){% unless forloop.last %}, {% endunless %}{% endfor %}
+                        {%- endif %}
+                        {%- if a.date != blank %}
+                        - **Analysis date:** {{ a.date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'domain' %}
+                        {%- if a.threat_severity.threat_severity_level != blank %}
+                        - **Severity:** {{ a.threat_severity.threat_severity_level }}{% if a.threat_severity.level_description != blank %} ({{ a.threat_severity.level_description }}){% endif %}
+                        {%- endif %}
+                        {%- if a.tld != blank or a.registrar != blank %}
+                        - **Domain info:** {% if a.tld != blank %}TLD {{ a.tld }}{% endif %}{% if a.registrar != blank %}{% if a.tld != blank %}, {% endif %}registrar {{ a.registrar }}{% endif %}
+                        {%- endif %}
+                          {%- when 'ip_address' %}
+                        {%- if a.as_owner != blank or a.asn != blank or a.network != blank %}
+                        - **Network:** {% if a.as_owner != blank %}{{ a.as_owner }}{% endif %}{% if a.asn != blank %} (AS{{ a.asn }}){% endif %}{% if a.network != blank %}, {{ a.network }}{% endif %}
+                        {%- endif %}
+                        {%- if a.country != blank or a.continent != blank %}
+                        - **Geolocation:** {% if a.country != blank %}{{ a.country }}{% endif %}{% if a.continent != blank %}, {{ a.continent }}{% endif %}
+                        {%- endif %}
+                          {%- when 'resolution' %}
+                        {%- if a.host_name != blank %}
+                        - **Host name:** {{ a.host_name }}
+                        {%- endif %}
+                        {%- if a.date != blank %}
+                        - **Resolved:** {{ a.date | date: '%Y-%m-%d' }}{% if a.resolver != blank %} via {{ a.resolver }}{% endif %}
+                        {%- endif %}
+                          {%- when 'file' %}
+                        {%- assign fname = a.meaningful_name | default: a.names[0] -%}
+                        {%- if fname != blank %}
+                        - **Name:** {{ fname }}
+                        {%- endif %}
+                        {%- if a.type_description != blank or a.size != blank %}
+                        - **Type:** {% if a.type_description != blank %}{{ a.type_description }}{% endif %}{% if a.size != blank %}, {{ a.size }} bytes{% endif %}
+                        {%- endif %}
+                        {%- if a.first_submission_date != blank %}
+                        - **First submitted:** {{ a.first_submission_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'url' %}
+                        {%- if a.title != blank %}
+                        - **Title:** {{ a.title }}
+                        {%- endif %}
+                        {%- if a.last_final_url != blank %}
+                        - **Final URL:** {{ a.last_final_url }}
+                        {%- endif %}
+                        {%- if a.threat_names.size > 0 %}
+                        - **Threat names:** {{ a.threat_names | join: ', ' }}
+                        {%- endif %}
+                          {%- when 'vote' %}
+                        - **Verdict:** {{ a.verdict }}{% if a.value != blank %} (value {{ a.value }}){% endif %}
+                        {%- if a.date != blank %}
+                        - **Date:** {{ a.date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                          {%- when 'comment' %}
+                        {%- assign comment_line = a.text | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                        - **Comment:** {{ comment_line }}
+                          {%- when 'collection' %}
+                        {%- if a.name != blank %}
+                        - **Name:** {{ a.name }}
+                        {%- endif %}
+                        {%- if a.collection_type != blank %}
+                        - **Type:** {{ a.collection_type }}
+                        {%- endif %}
+                        {%- assign summary_raw = a.executive_summary | default: a.analyst_comment | default: a.description -%}
+                        {%- if summary_raw != blank %}
+                        {%- assign summary_line = summary_raw | strip_html | replace: '\n', ' ' | replace: '  ', ' ' | strip | truncate: 400 %}
+                        - **Summary:** {{ summary_line }}
+                        {%- endif %}
+                          {%- when 'ssl_cert' %}
+                        {%- if a.subject.CN != blank or a.issuer.CN != blank %}
+                        - **Certificate:** {% if a.subject.CN != blank %}CN={{ a.subject.CN }}{% endif %}{% if a.issuer.CN != blank %}, issued by {{ a.issuer.CN }}{% endif %}
+                        {%- endif %}
+                        {%- if a.validity.not_before != blank or a.validity.not_after != blank %}
+                        - **Valid:** {{ a.validity.not_before }} to {{ a.validity.not_after }}
+                        {%- endif %}
+                          {%- when 'graph' %}
+                        {%- if a.graph_data.description != blank %}
+                        - **Description:** {{ a.graph_data.description }}
+                        {%- endif %}
+                        {%- if a.nodes.size > 0 %}
+                        - **Nodes:** {{ a.nodes.size }}
+                        {%- endif %}
+                        {%- if a.creation_date != blank %}
+                        - **Created:** {{ a.creation_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- if a.views_count != blank or a.comments_count != blank %}
+                        - **Activity:** {{ a.views_count | default: 0 }} view(s), {{ a.comments_count | default: 0 }} comment(s)
+                        {%- endif %}
+                          {%- when 'whois' %}
+                        {%- if a.first_seen_date != blank %}
+                        - **First seen:** {{ a.first_seen_date | date: '%Y-%m-%d' }}
+                        {%- endif %}
+                        {%- assign whois_pairs = a.whois_map | entries -%}
+                        {%- if whois_pairs.size > 0 %}
+                        - **WHOIS fields:**
+                        {%- for pair in whois_pairs limit: 10 %}
+                          - {{ pair.key }}: {{ pair.value }}
+                        {%- endfor %}
+                        {%- if whois_pairs.size > 10 %}
+                          - _(and {{ whois_pairs.size | minus: 10 }} more - see the full document)_
+                        {%- endif %}
+                        {%- endif %}
+                        {%- endcase %}
+                        {%- if stats != blank %}
+                        - **Last analysis:** {{ stats.malicious | default: 0 }} malicious, {{ stats.suspicious | default: 0 }} suspicious, {{ stats.harmless | default: 0 }} harmless, {{ stats.undetected | default: 0 }} undetected
+                        {%- endif %}
+                        {%- if a.reputation != blank %}
+                        - **Reputation:** {{ a.reputation }}
+                        {%- endif %}
+                        {%- if tags.size > 0 %}
+                        - **Tags:** {{ tags | join: ', ' }}
+                        {%- endif %}
+                        {% if steps.index_relationship_item.error != blank %}_Not indexed: this item's response could not be stored (see the workflow's execution log for detail)._{% elsif variables.doc_link_base != blank %}[Open {{ t }} document in Discover](<{{ variables.doc_link_base }}?id={{ variables.item_doc_id }}>){% else %}Full document in index `{{ consts.index }}`, document
+                        ```
+                        {{ variables.item_doc_id }}
+                        ```
+                        {% endif %}
+
+                  - name: wrap_note_section
+                    type: data.set
+                    with:
+                      item_note_section_arr: "${{ variables.item_note_section | split: '@@GTI_NOTE_SEP@@' }}"
+
+                  - name: accumulate_note_section
+                    type: data.set
+                    with:
+                      note_sections: "${{ variables.note_sections | concat: variables.item_note_section_arr }}"
+
+              - name: advance_cursor
+                type: data.set
+                with:
+                  any_success: true
+                  page_cursor: "{{ variables.page_next_cursor }}"
+                  collected: "${{ variables.collected | plus: variables.page_items.size }}"
+              - name: eval_has_more
+                type: data.set
+                with:
+                  has_more: "${{ variables.page_next_cursor != blank }}"
+
+          - name: handle_page_error
+            type: if
+            condition: "${{ steps.get_url_relationship.error != blank }}"
+            steps:
+              - name: stop_on_error
+                type: data.set
+                with:
+                  has_more: false
+                  fetch_incomplete: true
+                  fetch_error: "${{ steps.get_url_relationship.error }}"
+
+      - name: compute_truncated
+        type: data.set
+        with:
+          truncated: "${{ variables.has_more == true }}"
+
+      - name: compute_run_status
+        type: data.set
+        with:
+          run_status: "{% if variables.any_success != true %}failed{% elsif variables.fetch_incomplete == true or variables.truncated == true %}partial{% else %}succeeded{% endif %}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: variables.observable | append: '-' | append: inputs.relationship | append: '-run-summary' | sha256 }}"
+
+      - name: write_run_summary
+        type: if
+        condition: "${{ variables.run_status != 'succeeded' }}"
+        steps:
+          - name: index_run_summary
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_relationship
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ variables.fetch_error.message }}"
+                  type: "{{ variables.fetch_error.type }}"
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                relationship: "{{ inputs.relationship }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                pagination:
+                  collected: "${{ variables.collected }}"
+                  fetch_incomplete: "${{ variables.fetch_incomplete }}"
+                  truncated: "${{ variables.truncated }}"
+                  next_cursor: "{{ variables.page_cursor }}"
+            on-failure:
+              continue: true
+
+      - name: skip_on_total_failure
+        type: if
+        condition: "${{ variables.any_success != true }}"
+        steps:
+          - name: log_fetch_failure
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getUrlRelationship failed for {{ variables.field_name }} ({{ variables.observable }}), relationship {{ inputs.relationship }}.
+                {{ variables.fetch_error | json }}
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                    _Managed by the GTI URL Relationships workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{%- if variables.real_url_id != blank -%}{{ variables.real_url_id }}{%- else -%}{{ variables.canonical_url | sha256 }}{%- endif -%})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve any data from GTI.
+                    > `{{ variables.fetch_error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: skip_when_empty
+        type: if
+        condition: "${{ variables.collected == 0 }}"
+        steps:
+          - name: log_empty
+            type: console
+            with:
+              message: >-
+                GTI has no {{ inputs.relationship }} relationship data for {{ variables.observable }}.
+                Nothing written.
+          - name: skip_empty_iteration
+            type: loop.continue
+
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and variables.collected > 0 }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI URL Relationship: ' | append: variables.observable | append: ' (' | append: inputs.relationship | append: ')' -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI URL Relationship: {{ variables.observable }} ({{ inputs.relationship }})
+
+                _Managed by the GTI URL Relationships workflow. This note is replaced on every run and describes only what this run fetched; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{%- if variables.real_url_id != blank -%}{{ variables.real_url_id }}{%- else -%}{{ variables.canonical_url | sha256 }}{%- endif -%})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                **STATUS: {{ variables.run_status }}.** {{ variables.collected }} {{ inputs.relationship }} object(s) retrieved.
+
+                {%- if variables.fetch_incomplete %}
+
+                > **Incomplete:** retrieval stopped early because a GTI API request failed; results below may be missing further items.
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+
+                > **Unexpectedly large result set:** stopped after {{ variables.collected }} items as a safety limit; GTI still had more to page through. Re-run standalone with `cursor: {{ variables.page_cursor }}` to continue.
+                {%- endif %}
+
+                {%- for section in variables.note_sections %}
+                {{ section }}
+                {% endfor %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:url-relationship"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank and variables.collected > 0 }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: {{ variables.run_status }} - GTI URL relationship {{ inputs.relationship }} for {{ variables.observable }}: {{ variables.collected }} object(s) retrieved.
+                {%- if variables.fetch_incomplete %}
+                (retrieval stopped early due to a GTI API error; results may be incomplete)
+                {%- endif %}
+                {%- if variables.truncated and variables.fetch_incomplete != true %}
+                (safety limit reached after {{ variables.collected }} items; GTI still had more - re-run with cursor: {{ variables.page_cursor }} to continue)
+                {%- endif %}
+                Indexed to {{ consts.index }}, one document per related object.

--- a/examples/integrations/google-threat-intelligence/gti-url-relationships.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-url-relationships.yaml
@@ -188,11 +188,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.url != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-url-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-url-report.yaml
@@ -1,0 +1,591 @@
+# Retrieves the GTI reputation and detection report for a URL and indexes
+# the full response. When run against an alert (paths 1/2) it also writes a
+# summary note and an alert tag; a standalone run (path 3) only indexes.
+# getUrlReport takes no limit/cursor - a single-object report, not paginated.
+version: '1'
+name: GTI URL Report
+description: >-
+  Retrieve the Google Threat Intelligence reputation and detection report for
+  a URL. Indexes the full response and summarises it on the triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - url-report
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-url-report
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["url.full", "url.original"]
+  gti_ui_base: https://www.virustotal.com/gui/url
+  empty_arr: []
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: url
+        type: string
+        required: false
+        description: >-
+          URL in its natural form, e.g. "https://example.com/path". Leave
+          blank when running against an alert, the URL is read from the
+          alert instead.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.url != blank -%}
+        {"field":"manual","value":"{{ inputs.url | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable URL found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the url input. Nothing to look up.
+
+  - name: enrich_each_url
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_observable
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | append: '-run-summary' | sha256 }}"
+
+      - name: get_url_report
+        type: google_threat_intelligence.getUrlReport
+        connector-id: "{{ consts.gti_connector_id }}"
+        with:
+          url: "{{ foreach.item.value }}"
+        on-failure:
+          retry:
+            max-attempts: 2
+            delay: 3s
+          continue: true
+
+      - name: skip_on_fetch_error
+        type: if
+        condition: "${{ steps.get_url_report.error != blank }}"
+        steps:
+          - name: log_fetch_error
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI getUrlReport failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ steps.get_url_report.error | json }}
+
+          - name: write_fetch_failure
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_report
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ steps.get_url_report.error.message }}"
+                  type: "{{ steps.get_url_report.error.type }}"
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+            on-failure:
+              continue: true
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              # Same marker the success-path note uses, so this replaces it in place.
+              - name: prepare_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Report: ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Report: {{ variables.observable }}
+
+                    _Managed by the GTI URL Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{{ variables.observable | sha256 }})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The last refresh attempt could not retrieve data from GTI.
+                    > `{{ steps.get_url_report.error.message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration
+            type: loop.continue
+
+      - name: stash_iter
+        type: data.set
+        with:
+          attrs: "${{ steps.get_url_report.output.data.attributes }}"
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+
+      # categories is a vendor-name-keyed map, flattened via entries so a new
+      # vendor never grows this summary block's own field count.
+      - name: summarise
+        type: data.set
+        with:
+          verdict: "{{ variables.attrs.gti_assessment.verdict.value | default: 'UNKNOWN' }}"
+          severity: "{{ variables.attrs.gti_assessment.severity.value | default: 'UNKNOWN' }}"
+          threat_score: "{{ variables.attrs.gti_assessment.threat_score.value | default: 0 }}"
+          description: "{{ variables.attrs.gti_assessment.description | replace: '\n', ' ' | replace: '  ', ' ' | strip }}"
+          malicious_count: "{{ variables.attrs.last_analysis_stats.malicious | default: 0 }}"
+          suspicious_count: "{{ variables.attrs.last_analysis_stats.suspicious | default: 0 }}"
+          harmless_count: "{{ variables.attrs.last_analysis_stats.harmless | default: 0 }}"
+          undetected_count: "{{ variables.attrs.last_analysis_stats.undetected | default: 0 }}"
+          last_analysis_date: "{{ variables.attrs.last_analysis_date }}"
+          reputation: "{{ variables.attrs.reputation | default: 0 }}"
+          votes_harmless: "{{ variables.attrs.total_votes.harmless | default: 0 }}"
+          votes_malicious: "{{ variables.attrs.total_votes.malicious | default: 0 }}"
+          title: "{{ variables.attrs.title }}"
+          final_url: "{{ variables.attrs.last_final_url }}"
+          http_code: "{{ variables.attrs.last_http_response_code }}"
+          tld: "{{ variables.attrs.tld }}"
+          web_category: "{{ variables.attrs.web_category }}"
+          tags: "${{ variables.attrs.tags }}"
+          threat_names: "${{ variables.attrs.threat_names | default: consts.empty_arr }}"
+          redirection_chain: "${{ variables.attrs.redirection_chain | default: consts.empty_arr }}"
+          crowdsourced_context: "${{ variables.attrs.crowdsourced_context | default: consts.empty_arr }}"
+          categories_list: |-
+            {%- assign cats = variables.attrs.categories | default: consts.empty_arr | entries -%}
+            {%- for pair in cats -%}
+              {%- if forloop.first == false %}, {% endif -%}{{ pair.key }}: {{ pair.value }}
+            {%- endfor -%}
+
+      - name: index_enrichment
+        type: elasticsearch.index
+        with:
+          index: "{{ consts.index }}"
+          id: "{{ variables.doc_id }}"
+          document:
+            "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+            event:
+              kind: enrichment
+              category: threat
+              dataset: gti_soar.url_report
+            observable:
+              type: url
+              field: "{{ variables.field_name }}"
+              value: "{{ variables.observable }}"
+            trigger_mode: "{{ variables.trigger_mode }}"
+            kibana:
+              alert:
+                uuid: "{{ variables.target_id }}"
+                index: "{{ variables.target_index }}"
+            rule:
+              id: "{{ variables.rule_id }}"
+              name: "{{ variables.rule_name }}"
+            workflow:
+              execution_id: "{{ execution.id }}"
+            summary:
+              verdict: "{{ variables.verdict }}"
+              severity: "{{ variables.severity }}"
+              description: "{{ variables.description }}"
+              threat_score: "${{ variables.threat_score | plus: 0 }}"
+              malicious_count: "${{ variables.malicious_count | plus: 0 }}"
+              suspicious_count: "${{ variables.suspicious_count | plus: 0 }}"
+              harmless_count: "${{ variables.harmless_count | plus: 0 }}"
+              undetected_count: "${{ variables.undetected_count | plus: 0 }}"
+              last_analysis_date: "{{ variables.last_analysis_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+              reputation: "${{ variables.reputation | plus: 0 }}"
+              votes_harmless: "${{ variables.votes_harmless | plus: 0 }}"
+              votes_malicious: "${{ variables.votes_malicious | plus: 0 }}"
+              title: "{{ variables.title }}"
+              final_url: "{{ variables.final_url }}"
+              http_code: "${{ variables.http_code | plus: 0 }}"
+              tld: "{{ variables.tld }}"
+              web_category: "{{ variables.web_category }}"
+              categories: "{{ variables.categories_list }}"
+              tags: "${{ variables.tags }}"
+              threat_names: "${{ variables.threat_names }}"
+              redirection_chain: "${{ variables.redirection_chain }}"
+              crowdsourced_context: "${{ variables.crowdsourced_context }}"
+            gti: "${{ steps.get_url_report.output.data }}"
+        on-failure:
+          continue: true
+
+      # Paths 1/2 only, and only once the document actually exists.
+      - name: annotate_alert
+        type: if
+        condition: "${{ variables.target_id != blank and steps.index_enrichment.error == blank }}"
+        steps:
+
+          - name: find_existing_note
+            type: kibana.request
+            with:
+              method: GET
+              path: /api/note
+              query:
+                documentIds: "{{ variables.target_id }}"
+            on-failure:
+              continue: true
+
+          - name: build_doc_link
+            type: data.set
+            with:
+              doc_link: |-
+                {%- if variables.data_view_id != blank -%}
+                  {%- assign sp = '' -%}
+                  {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                  {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.doc_id }}
+                {%- endif -%}
+
+          - name: prepare_note
+            type: data.set
+            with:
+              existing_note_id: |-
+                {%- assign marker = 'GTI URL Report: ' | append: variables.observable -%}
+                {%- for n in steps.find_existing_note.output.notes -%}
+                  {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                {%- endfor -%}
+              note_text: |-
+                ## GTI URL Report: {{ variables.observable }}
+
+                _Managed by the GTI URL Report workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{%- if steps.get_url_report.output.data.id != blank -%}{{ steps.get_url_report.output.data.id }}{%- else -%}{{ variables.observable | sha256 }}{%- endif -%})
+                Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                ---
+
+                ### Assessment
+                - **Verdict:** {{ variables.verdict }}
+                - **Severity:** {{ variables.severity }}
+                - **Threat score:** {{ variables.threat_score }}
+                - **Reputation:** {{ variables.reputation }}
+                {%- if variables.description != blank %}
+                - **GTI summary:** {{ variables.description }}
+                {%- endif %}
+
+                ### Detection
+                - **Last analysis:** {{ variables.malicious_count }} malicious, {{ variables.suspicious_count }} suspicious, {{ variables.harmless_count }} harmless, {{ variables.undetected_count }} undetected{% if variables.last_analysis_date != blank %} (as of {{ variables.last_analysis_date | date: '%Y-%m-%d' }}){% endif %}
+                {%- if variables.votes_harmless != blank or variables.votes_malicious != blank %}
+                - **Community votes:** {{ variables.votes_harmless | default: 0 }} harmless, {{ variables.votes_malicious | default: 0 }} malicious
+                {%- endif %}
+                {%- if variables.threat_names.size > 0 %}
+                - **Threat names:** {{ variables.threat_names | join: ', ' }}
+                {%- endif %}
+                {%- if variables.title != blank or variables.final_url != blank or variables.http_code != blank or variables.web_category != blank %}
+
+                ### URL info
+                {%- if variables.title != blank %}
+                - **Page title:** {{ variables.title }}
+                {%- endif %}
+                {%- if variables.final_url != blank and variables.final_url != variables.observable %}
+                - **Final destination:** {{ variables.final_url }}
+                {%- endif %}
+                {%- if variables.http_code != blank %}
+                - **Last HTTP status:** {{ variables.http_code }}
+                {%- endif %}
+                {%- if variables.web_category != blank %}
+                - **Web category:** {{ variables.web_category }}
+                {%- endif %}
+                {%- if variables.tld != blank %}
+                - **TLD:** {{ variables.tld }}
+                {%- endif %}
+                {%- endif %}
+                {%- if variables.redirection_chain.size > 1 %}
+
+                ### Redirection chain
+                {%- for hop in variables.redirection_chain %}
+                - {{ hop }}
+                {%- endfor %}
+                {%- endif %}
+                {%- if variables.categories_list != blank %}
+
+                ### Categories
+                - {{ variables.categories_list }}
+                {%- endif %}
+                {%- if variables.tags.size > 0 %}
+
+                ### Tags
+                - {{ variables.tags | join: ', ' }}
+                {%- endif %}
+                {%- if variables.crowdsourced_context.size > 0 %}
+
+                ### Community context
+                {%- for c in variables.crowdsourced_context %}
+                {%- assign detail_line = c.details | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                - **{{ c.title }}** ({{ c.severity | default: 'unknown' }} severity, via {{ c.source }}){% if c.timestamp != blank %}, {{ c.timestamp | date: '%Y-%m-%d' }}{% endif %}: {{ detail_line }}
+                {%- endfor %}
+                {%- endif %}
+
+                ---
+                {% if variables.doc_link != blank %}Full response: [open the stored document in Discover](<{{ variables.doc_link }}>){% else %}Full response in index `{{ consts.index }}`, document
+                ```
+                {{ variables.doc_id }}
+                ```
+                {% endif %}
+
+          - name: write_note
+            type: if
+            condition: "${{ variables.existing_note_id != blank }}"
+            steps:
+              - name: update_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    noteId: "{{ variables.existing_note_id }}"
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+            else:
+              - name: create_note
+                type: kibana.request
+                with:
+                  method: PATCH
+                  path: /api/note
+                  headers:
+                    kbn-xsrf: "true"
+                    Content-Type: application/json
+                  body:
+                    note:
+                      eventId: "{{ variables.target_id }}"
+                      timelineId: ""
+                      note: "{{ variables.note_text }}"
+                on-failure:
+                  continue: true
+
+          - name: tag_alert
+            type: security.setAlertTags
+            with:
+              alert_ids: "{{ variables.target_id }}"
+              tags_to_add:
+                - "gti:url-report"
+            on-failure:
+              continue: true
+
+      # Path 3: no alert to annotate.
+      - name: report_standalone
+        type: if
+        condition: "${{ variables.target_id == blank }}"
+        steps:
+          - name: log_document_reference
+            type: console
+            with:
+              message: |-
+                STATUS: succeeded - GTI URL report for {{ variables.observable }}: verdict {{ variables.verdict }}, severity {{ variables.severity }}.
+                Indexed to {{ consts.index }} / {{ variables.doc_id }}

--- a/examples/integrations/google-threat-intelligence/gti-url-report.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-url-report.yaml
@@ -143,11 +143,21 @@ steps:
           {%- assign node = event.alerts[0] -%}
           {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
           {%- if node != blank -%}
-            {%- unless seen contains node -%}
-              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
-              {%- assign sep = ',' -%}
-              {%- assign seen = seen | push: node -%}
-            {%- endunless -%}
+            {%- assign node_str = node | join: ',' -%}
+            {%- if node_str == node -%}
+              {%- assign candidates = consts.empty_arr | push: node -%}
+            {%- else -%}
+              {%- assign candidates = node -%}
+            {%- endif -%}
+            {%- for candidate in candidates -%}
+              {%- if candidate != blank -%}
+                {%- unless seen contains candidate -%}
+                  {{ sep }}{"field":"{{ f | strip }}","value":"{{ candidate }}"}
+                  {%- assign sep = ',' -%}
+                  {%- assign seen = seen | push: candidate -%}
+                {%- endunless -%}
+              {%- endif -%}
+            {%- endfor -%}
           {%- endif -%}
         {%- endfor -%}
       {%- elsif inputs.url != blank -%}

--- a/examples/integrations/google-threat-intelligence/gti-url-scan-private.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-url-scan-private.yaml
@@ -1,0 +1,1056 @@
+# Submits a URL to Google Threat Intelligence for a private analysis (not
+# shared with the wider GTI community), polls until the analysis completes,
+# then retrieves and indexes the full report. Paths 1/2 also write a summary
+# note and an alert tag; path 3 only indexes. Unlike GTI URL Report, this one
+# submits new content to GTI rather than reading an already-computed verdict,
+# so it chains three actions (submit, poll, retrieve) instead of one.
+version: '1'
+name: GTI URL Scan (Private)
+description: >-
+  Submit a URL to Google Threat Intelligence for private analysis (not shared
+  with the wider GTI community), poll until the scan completes, then retrieve
+  and index the full report. Summarises the result on the triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - url-scan-private
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-url-scan-private
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["url.full", "url.original"]
+  # No consts.gti_ui_base here, unlike GTI URL Report/Relationships - there is no confirmed
+  # public GTI GUI URL pattern for a private analysis; the note links to the stored document
+  # in Discover instead (see build_doc_link below).
+  empty_arr: []
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: url
+        type: string
+        required: false
+        description: >-
+          URL in its natural form, e.g. "https://example.com/path". Leave
+          blank when running against an alert, the URL is read from the
+          alert instead.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: user_agent
+        type: string
+        required: false
+        description: >-
+          User-Agent string to present when GTI retrieves the URL. Leave
+          blank to use GTI's own default.
+      - name: sandboxes
+        type: string
+        required: false
+        description: >-
+          Comma separated list of sandboxes to detonate in, e.g.
+          "chrome_headless_linux", "cape_win", "zenbox_windows". Leave blank
+          to use GTI's own default set.
+      - name: retention_period_days
+        type: number
+        required: false
+        description: >-
+          Number of days GTI retains this analysis. 1-28. Leave blank to use
+          GTI's own default (1 day).
+      - name: storage_region
+        type: string
+        required: false
+        description: >-
+          Region the analysis is stored in, e.g. "US", "CA", "EU", "GB".
+          Leave blank to use your account's own group preference - GTI has
+          no single fixed default for this one.
+      - name: interaction_sandbox
+        type: string
+        required: false
+        description: >-
+          Sandbox used for interactive analysis, e.g. "cape_win". Leave
+          blank to use GTI's own default ("cape_win").
+      - name: interaction_timeout
+        type: number
+        required: false
+        description: >-
+          Interactive analysis duration in seconds. 60-1800. Leave blank to
+          use GTI's own default (60 seconds).
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.url != blank -%}
+        {"field":"manual","value":"{{ inputs.url | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable URL found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the url input. Nothing to scan.
+
+  - name: scan_each_url
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_observable
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | append: '-run-summary' | sha256 }}"
+
+      # --- 1. Submit ------------------------------------------------------
+      # Optional fields use ${{ }} (native-value evaluation), not {{ }}
+      # (string rendering), so a genuinely-unset input resolves to undefined
+      # rather than an empty string, and the key is omitted from the request
+      # entirely instead of being sent as "" - confirmed live.
+      - name: submit_private_scan
+        type: google_threat_intelligence.scanPrivateUrl
+        connector-id: "{{ consts.gti_connector_id }}"
+        with:
+          url: "{{ variables.observable }}"
+          userAgent: "${{ inputs.user_agent }}"
+          sandboxes: "${{ inputs.sandboxes }}"
+          retentionPeriodDays: "${{ inputs.retention_period_days }}"
+          storageRegion: "${{ inputs.storage_region }}"
+          interactionSandbox: "${{ inputs.interaction_sandbox }}"
+          interactionTimeout: "${{ inputs.interaction_timeout }}"
+        on-failure:
+          retry:
+            max-attempts: 2
+            delay: 3s
+          continue: true
+
+      - name: submission_failed
+        type: if
+        condition: "${{ steps.submit_private_scan.error != blank or steps.submit_private_scan.output.data.id == blank }}"
+        steps:
+          - name: log_submission_error
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI scanPrivateUrl failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ steps.submit_private_scan.error | json }}
+
+          - name: write_submission_failure
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_private
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ steps.submit_private_scan.error.message }}"
+                  type: "{{ steps.submit_private_scan.error.type }}"
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+            on-failure:
+              continue: true
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_submission_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_submission_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: prepare_submission_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Private): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_submission_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Private): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Private) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}`
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The scan could not be submitted to GTI.
+                    > `{{ steps.submit_private_scan.error.message }}`
+                    > See the indexed failure record for detail: index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+
+              - name: write_submission_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_submission_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_submission_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration_on_submission_failure
+            type: loop.continue
+
+      # --- 2. Poll ----------------------------------------------------
+      # Modeled on Censys's own shipped Rescan workflow (examples/integrations/
+      # censys/rescan.yaml, elastic/workflows#17): poll immediately, wait only
+      # if still not done (not wait-then-poll), gated by an explicit `if` on
+      # the tracked id, max-iterations 60 at a 10s interval (10-minute
+      # ceiling) matching that workflow's own shipped, live-tested value.
+      - name: init_polling
+        type: data.set
+        with:
+          analysis_id: "{{ steps.submit_private_scan.output.data.id }}"
+          scan_status: ""
+          url_report_id: ""
+
+      - name: poll_scan_status_gate
+        type: if
+        condition: "${{ variables.analysis_id != blank }}"
+        steps:
+          - name: poll_until_complete
+            type: while
+            # queued / in-progress / blank (not yet reported) keep polling;
+            # anything else - completed, poll_error, or any status word GTI
+            # might add later that this workflow doesn't recognize - stops
+            # the loop rather than spinning on an unrecognized value.
+            condition: "${{ variables.scan_status == '' or variables.scan_status == 'queued' or variables.scan_status == 'in-progress' }}"
+            max-iterations: 60   # literal only (see rescan.yaml); keep this and the note text below in sync
+            steps:
+              - name: get_private_analysis
+                type: google_threat_intelligence.getPrivateAnalysis
+                connector-id: "{{ consts.gti_connector_id }}"
+                with:
+                  analysisId: "{{ variables.analysis_id }}"
+                on-failure:
+                  retry:
+                    max-attempts: 2
+                    delay: 3s
+                  continue: true
+
+              - name: record_poll_success
+                type: if
+                condition: "${{ steps.get_private_analysis.error == blank }}"
+                steps:
+                  - name: stash_status
+                    type: data.set
+                    with:
+                      scan_status: "{{ steps.get_private_analysis.output.data.attributes.status }}"
+                      # meta is a sibling of data on this connector's output, not nested under it -
+                      # confirmed live; "output.data.meta..." silently rendered blank every time.
+                      url_report_id: "{{ steps.get_private_analysis.output.meta.url_info.id | default: variables.url_report_id }}"
+
+              - name: record_poll_error
+                type: if
+                condition: "${{ steps.get_private_analysis.error != blank }}"
+                steps:
+                  - name: stash_poll_error
+                    type: data.set
+                    with:
+                      scan_status: "poll_error"
+                      poll_error_message: "{{ steps.get_private_analysis.error.message }}"
+                      poll_error_type: "{{ steps.get_private_analysis.error.type }}"
+
+              - name: wait_if_not_done
+                type: if
+                condition: "${{ variables.scan_status == 'queued' or variables.scan_status == 'in-progress' }}"
+                steps:
+                  - name: wait_between_polls
+                    type: wait
+                    with:
+                      duration: 10s
+
+      # --- 3. Retrieve, only if the poll loop reached a usable completion -
+      - name: classify_poll_outcome
+        type: data.set
+        with:
+          # "completed but no meta.url_info.id" is treated the same as
+          # "still pending" (falls to the else branch below) rather than as
+          # its own error case - conservative on purpose.
+          scan_outcome: |-
+            {%- if variables.scan_status == 'completed' and variables.url_report_id != blank -%}ready
+            {%- elsif variables.scan_status == 'poll_error' -%}error
+            {%- else -%}pending
+            {%- endif -%}
+
+      - name: retrieve_report
+        type: if
+        condition: "${{ variables.scan_outcome == 'ready' }}"
+        steps:
+          - name: get_private_url_report
+            type: google_threat_intelligence.getPrivateUrlReport
+            connector-id: "{{ consts.gti_connector_id }}"
+            with:
+              urlId: "{{ variables.url_report_id }}"
+            on-failure:
+              retry:
+                max-attempts: 2
+                delay: 3s
+              continue: true
+
+          - name: stash_retrieval_success
+            type: if
+            condition: "${{ steps.get_private_url_report.error == blank }}"
+            steps:
+              - name: stash_attrs
+                type: data.set
+                with:
+                  attrs: "${{ steps.get_private_url_report.output.data.attributes }}"
+                  retrieval_ok: true
+
+          - name: stash_retrieval_error
+            type: if
+            condition: "${{ steps.get_private_url_report.error != blank }}"
+            steps:
+              - name: stash_retrieval_error_detail
+                type: data.set
+                with:
+                  retrieval_ok: false
+                  retrieval_error_message: "{{ steps.get_private_url_report.error.message }}"
+                  retrieval_error_type: "{{ steps.get_private_url_report.error.type }}"
+
+      - name: compute_run_status
+        type: data.set
+        with:
+          run_status: |-
+            {%- if variables.scan_outcome == 'ready' and variables.retrieval_ok == true -%}succeeded
+            {%- elsif variables.scan_outcome == 'error' or variables.retrieval_ok == false -%}failed
+            {%- else -%}partial
+            {%- endif -%}
+
+      - name: log_run_status
+        type: console
+        with:
+          message: |-
+            STATUS: {{ variables.run_status }} - GTI URL Scan (Private) for {{ variables.observable }}. Analysis id: {{ variables.analysis_id }}. Last poll status: {{ variables.scan_status }}.
+
+      # --- 4a. failed: run-summary doc, failure note, no tag, skip rest ---
+      - name: handle_failed
+        type: if
+        condition: "${{ variables.run_status == 'failed' }}"
+        steps:
+          - name: write_run_summary_failed
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_private
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ variables.poll_error_message | default: variables.retrieval_error_message }}"
+                  type: "{{ variables.poll_error_type | default: variables.retrieval_error_type }}"
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                scan:
+                  analysis_id: "{{ variables.analysis_id }}"
+                  last_status: "{{ variables.scan_status }}"
+            on-failure:
+              continue: true
+
+          - name: annotate_alert_failed
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failed
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              - name: prepare_failed_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Private): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failed.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Private): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Private) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}`
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** Analysis id `{{ variables.analysis_id }}`. {% if variables.scan_outcome == 'error' %}Polling GTI for this analysis's status failed.{% else %}Retrieving the completed report from GTI failed.{% endif %}
+                    > `{{ variables.poll_error_message | default: variables.retrieval_error_message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failed_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failed_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failed_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration_on_failure
+            type: loop.continue
+
+      # --- 4b. partial: run-summary doc, "still processing" note, tagged --
+      - name: handle_partial
+        type: if
+        condition: "${{ variables.run_status == 'partial' }}"
+        steps:
+          - name: write_run_summary_partial
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_private
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: ""
+                  type: ""
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                scan:
+                  analysis_id: "{{ variables.analysis_id }}"
+                  last_status: "{{ variables.scan_status }}"
+                  timed_out: true
+            on-failure:
+              continue: true
+
+          - name: annotate_alert_partial
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_partial
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: prepare_partial_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Private): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_partial.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Private): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Private) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}`
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: partial.** The scan was submitted successfully (analysis id `{{ variables.analysis_id }}`), but GTI had not finished analyzing it after 60 status checks (~10 minutes). Last known status: `{{ variables.scan_status }}`. This is not a failure - GTI may still be working on it. Re-run this workflow later to check again, or poll `getPrivateAnalysis`/`getPrivateUrlReport` directly with this analysis id.
+                    > Indexed to `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+
+              - name: write_partial_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_partial_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_partial_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+              # Real work happened - a scan was genuinely submitted and is in flight -
+              # so this still gets tagged, same as a paginated workflow's partial batch.
+              - name: tag_alert_partial
+                type: security.setAlertTags
+                with:
+                  alert_ids: "{{ variables.target_id }}"
+                  tags_to_add:
+                    - "gti:url-scan-private"
+                on-failure:
+                  continue: true
+
+          - name: standalone_log_partial
+            type: if
+            condition: "${{ variables.target_id == blank }}"
+            steps:
+              - name: log_partial_standalone
+                type: console
+                with:
+                  message: |-
+                    STATUS: partial - GTI still processing {{ variables.observable }} after 60 status checks (~10 minutes). Analysis id: {{ variables.analysis_id }}. Re-run later or poll directly with this id.
+
+          - name: skip_iteration_on_partial
+            type: loop.continue
+
+      # --- 4c. succeeded: full report, index, note, tag ------------------
+      # categories is a vendor-name-keyed map, flattened via entries so a new
+      # vendor never grows this summary block's own field count.
+      #
+      # Live-confirmed: a private scan of a URL with no prior public GTI history returns
+      # last_analysis_stats/last_analysis_date/
+      # reputation/total_votes/categories/web_category/context_attributes all null - these are
+      # aggregated-over-time / community fields that a brand-new private submission genuinely
+      # doesn't have yet, distinct from "0 detections". Only gti_assessment (GTI's own private
+      # verdict) is reliably present from the first successful retrieval. has_analysis_stats/
+      # has_reputation gate the note (below) so "not yet analyzed" is never rendered as "0/clean".
+      - name: summarise
+        type: data.set
+        with:
+          verdict: "{{ variables.attrs.gti_assessment.verdict.value | default: 'UNKNOWN' }}"
+          severity: "{{ variables.attrs.gti_assessment.severity.value | default: 'UNKNOWN' }}"
+          threat_score: "{{ variables.attrs.gti_assessment.threat_score.value | default: 0 }}"
+          description: "{{ variables.attrs.gti_assessment.description | replace: '\n', ' ' | replace: '  ', ' ' | strip }}"
+          has_analysis_stats: "${{ variables.attrs.last_analysis_stats != blank }}"
+          malicious_count: "{{ variables.attrs.last_analysis_stats.malicious | default: 0 }}"
+          suspicious_count: "{{ variables.attrs.last_analysis_stats.suspicious | default: 0 }}"
+          harmless_count: "{{ variables.attrs.last_analysis_stats.harmless | default: 0 }}"
+          undetected_count: "{{ variables.attrs.last_analysis_stats.undetected | default: 0 }}"
+          last_analysis_date: "{{ variables.attrs.last_analysis_date }}"
+          has_reputation: "${{ variables.attrs.reputation != blank }}"
+          reputation: "{{ variables.attrs.reputation | default: 0 }}"
+          has_votes: "${{ variables.attrs.total_votes != blank }}"
+          votes_harmless: "{{ variables.attrs.total_votes.harmless | default: 0 }}"
+          votes_malicious: "{{ variables.attrs.total_votes.malicious | default: 0 }}"
+          title: "{{ variables.attrs.title }}"
+          tld: "{{ variables.attrs.tld }}"
+          web_category: "{{ variables.attrs.web_category }}"
+          tags: "${{ variables.attrs.tags }}"
+          threat_names: "${{ variables.attrs.threat_names | default: consts.empty_arr }}"
+          crowdsourced_context: "${{ variables.attrs.crowdsourced_context | default: consts.empty_arr }}"
+          categories_list: |-
+            {%- assign cats = variables.attrs.categories | default: consts.empty_arr | entries -%}
+            {%- for pair in cats -%}
+              {%- if forloop.first == false %}, {% endif -%}{{ pair.key }}: {{ pair.value }}
+            {%- endfor -%}
+
+      - name: index_scan_result
+        type: if
+        condition: "${{ variables.run_status == 'succeeded' }}"
+        steps:
+          - name: index_enrichment
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_private
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                scan:
+                  analysis_id: "{{ variables.analysis_id }}"
+                  private: true
+                summary:
+                  verdict: "{{ variables.verdict }}"
+                  severity: "{{ variables.severity }}"
+                  description: "{{ variables.description }}"
+                  threat_score: "${{ variables.threat_score | plus: 0 }}"
+                  # false, not just an absent field, so "engines haven't run yet" is distinguishable
+                  # from "confirmed 0 detections" without having to compare against last_analysis_date too.
+                  analysis_stats_available: "${{ variables.has_analysis_stats }}"
+                  reputation_available: "${{ variables.has_reputation }}"
+                  votes_available: "${{ variables.has_votes }}"
+                  malicious_count: "${{ variables.malicious_count | plus: 0 }}"
+                  suspicious_count: "${{ variables.suspicious_count | plus: 0 }}"
+                  harmless_count: "${{ variables.harmless_count | plus: 0 }}"
+                  undetected_count: "${{ variables.undetected_count | plus: 0 }}"
+                  last_analysis_date: "{{ variables.last_analysis_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                  reputation: "${{ variables.reputation | plus: 0 }}"
+                  votes_harmless: "${{ variables.votes_harmless | plus: 0 }}"
+                  votes_malicious: "${{ variables.votes_malicious | plus: 0 }}"
+                  title: "{{ variables.title }}"
+                  tld: "{{ variables.tld }}"
+                  web_category: "{{ variables.web_category }}"
+                  categories: "{{ variables.categories_list }}"
+                  tags: "${{ variables.tags }}"
+                  threat_names: "${{ variables.threat_names }}"
+                  crowdsourced_context: "${{ variables.crowdsourced_context }}"
+                gti: "${{ steps.get_private_url_report.output.data }}"
+            on-failure:
+              continue: true
+
+          # Paths 1/2 only, and only once the document actually exists.
+          - name: annotate_alert_succeeded
+            type: if
+            condition: "${{ variables.target_id != blank and steps.index_enrichment.error == blank }}"
+            steps:
+
+              - name: find_existing_note_succeeded
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_doc_link
+                type: data.set
+                with:
+                  doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.doc_id }}
+                    {%- endif -%}
+
+              - name: prepare_succeeded_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Private): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_succeeded.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Private): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Private) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}`
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    **STATUS: succeeded.**
+
+                    ### Scan submission
+                    - **Analysis id:** {{ variables.analysis_id }}
+                    - **Private:** yes - not shared with the wider GTI community
+                    {%- if inputs.retention_period_days != blank %}
+                    - **Retention:** {{ inputs.retention_period_days }} day(s)
+                    {%- endif %}
+                    {%- if inputs.storage_region != blank %}
+                    - **Storage region:** {{ inputs.storage_region }}
+                    {%- endif %}
+                    {%- if inputs.sandboxes != blank %}
+                    - **Sandboxes:** {{ inputs.sandboxes }}
+                    {%- endif %}
+
+                    ### Assessment
+                    - **Verdict:** {{ variables.verdict }}
+                    - **Severity:** {{ variables.severity }}
+                    - **Threat score:** {{ variables.threat_score }}
+                    {%- if variables.has_reputation %}
+                    - **Reputation:** {{ variables.reputation }}
+                    {%- endif %}
+                    {%- if variables.description != blank %}
+                    - **GTI summary:** {{ variables.description }}
+                    {%- endif %}
+
+                    ### Detection
+                    {%- if variables.has_analysis_stats %}
+                    - **Last analysis:** {{ variables.malicious_count }} malicious, {{ variables.suspicious_count }} suspicious, {{ variables.harmless_count }} harmless, {{ variables.undetected_count }} undetected{% if variables.last_analysis_date != blank %} (as of {{ variables.last_analysis_date | date: '%Y-%m-%d' }}){% endif %}
+                    {%- else %}
+                    - **Multi-engine analysis:** not yet available - this URL has no prior public GTI history, so third-party engine results haven't run yet. The verdict above is GTI's own private assessment only; re-run this workflow later or check GTI directly for updated engine results.
+                    {%- endif %}
+                    {%- if variables.has_votes %}
+                    - **Community votes:** {{ variables.votes_harmless | default: 0 }} harmless, {{ variables.votes_malicious | default: 0 }} malicious
+                    {%- endif %}
+                    {%- if variables.threat_names.size > 0 %}
+                    - **Threat names:** {{ variables.threat_names | join: ', ' }}
+                    {%- endif %}
+                    {%- if variables.title != blank or variables.web_category != blank %}
+
+                    ### URL info
+                    {%- if variables.title != blank %}
+                    - **Page title:** {{ variables.title }}
+                    {%- endif %}
+                    {%- if variables.web_category != blank %}
+                    - **Web category:** {{ variables.web_category }}
+                    {%- endif %}
+                    {%- if variables.tld != blank %}
+                    - **TLD:** {{ variables.tld }}
+                    {%- endif %}
+                    {%- endif %}
+                    {%- if variables.categories_list != blank %}
+
+                    ### Categories
+                    - {{ variables.categories_list }}
+                    {%- endif %}
+                    {%- if variables.tags.size > 0 %}
+
+                    ### Tags
+                    - {{ variables.tags | join: ', ' }}
+                    {%- endif %}
+                    {%- if variables.crowdsourced_context.size > 0 %}
+
+                    ### Community context
+                    {%- for c in variables.crowdsourced_context %}
+                    {%- assign detail_line = c.details | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                    - **{{ c.title }}** ({{ c.severity | default: 'unknown' }} severity, via {{ c.source }}){% if c.timestamp != blank %}, {{ c.timestamp | date: '%Y-%m-%d' }}{% endif %}: {{ detail_line }}
+                    {%- endfor %}
+                    {%- endif %}
+
+                    ---
+                    {% if variables.doc_link != blank %}Full response: [open the stored document in Discover](<{{ variables.doc_link }}>){% else %}Full response in index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_succeeded_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_succeeded_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_succeeded_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+              - name: tag_alert_succeeded
+                type: security.setAlertTags
+                with:
+                  alert_ids: "{{ variables.target_id }}"
+                  tags_to_add:
+                    - "gti:url-scan-private"
+                on-failure:
+                  continue: true
+
+          # Path 3: no alert to annotate.
+          - name: report_standalone
+            type: if
+            condition: "${{ variables.target_id == blank }}"
+            steps:
+              - name: log_document_reference
+                type: console
+                with:
+                  message: |-
+                    STATUS: succeeded - GTI private URL scan for {{ variables.observable }}: verdict {{ variables.verdict }}, severity {{ variables.severity }}.
+                    Indexed to {{ consts.index }} / {{ variables.doc_id }}

--- a/examples/integrations/google-threat-intelligence/gti-url-scan-public.yaml
+++ b/examples/integrations/google-threat-intelligence/gti-url-scan-public.yaml
@@ -1,0 +1,997 @@
+# Submits a URL to Google Threat Intelligence for a public analysis, polls
+# until the analysis completes, then retrieves and indexes the full report.
+# Paths 1/2 also write a summary note and an alert tag; path 3 only indexes.
+# Unlike GTI URL Report, this one submits new content to GTI rather than
+# reading an already-computed verdict, so it chains three actions (submit,
+# poll, retrieve) instead of one. Public sibling of GTI URL Scan (Private) -
+# same pipeline shape, minus the six private-only optional parameters, plus a
+# real public GTI GUI link the private workflow deliberately doesn't have.
+version: '1'
+name: GTI URL Scan (Public)
+description: >-
+  Submit a URL to Google Threat Intelligence for public analysis, poll until
+  the scan completes, then retrieve and index the full report. Summarises the
+  result on the triggering alert.
+enabled: true
+
+tags:
+  - security
+  - threat-intel
+  - google-threat-intelligence
+  - url-scan-public
+
+consts:
+  gti_connector_id: REPLACE_WITH_GTI_CONNECTOR_ID
+  index: gti-soar-url-scan-public
+  # Alert fields checked in order; a value repeated across fields is enriched once.
+  # Default example fields - please update according to your own needs.
+  observable_fields: ["url.full", "url.original"]
+  gti_ui_base: https://www.virustotal.com/gui/url
+  empty_arr: []
+
+triggers:
+  - type: alert
+  - type: manual
+    inputs:
+      - name: url
+        type: string
+        required: false
+        description: >-
+          URL in its natural form, e.g. "https://example.com/path". Leave
+          blank when running against an alert, the URL is read from the
+          alert instead.
+      - name: alert_index
+        type: string
+        required: false
+        description: >-
+          Concrete alert index to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+      - name: alert_id
+        type: string
+        required: false
+        description: >-
+          Alert document _id to annotate. Filled in automatically when the
+          workflow is started from the alert table or flyout.
+
+steps:
+
+  # Self-provisions this workflow's index template so mapping settings apply
+  # before the first real write, rather than relying on manual setup.
+  - name: bootstrap_index_template
+    type: elasticsearch.request
+    with:
+      method: PUT
+      path: "_index_template/{{ consts.index }}"
+      body:
+        index_patterns: ["{{ consts.index }}"]
+        priority: 500
+        template:
+          settings:
+            index.mapping.total_fields.limit: 2000
+            index.mapping.total_fields.ignore_dynamic_beyond_limit: true
+            index.mapping.ignore_malformed: true
+    on-failure:
+      continue: true
+
+  - name: resolve_target_doc
+    type: data.set
+    with:
+      target_index: "{{ event.alerts[0]._index | default: inputs.alert_index }}"
+      target_id: "{{ event.alerts[0]._id | default: inputs.alert_id }}"
+      rule_id: "{{ event.rule.id }}"
+      rule_name: "{{ event.rule.name | default: 'Manual run' }}"
+
+  # execution.triggeredBy is the reliable discriminator; event.rule is populated on both paths 1 and 2.
+  - name: classify_trigger
+    type: data.set
+    with:
+      trigger_mode: "{% if execution.triggeredBy == 'alert' %}detection_rule{% elsif variables.target_id != blank %}manual_with_alert{% else %}manual_standalone{% endif %}"
+
+  # Only runs when there's an alert to annotate; falls back to plain text in the note if this fails.
+  - name: find_data_view
+    if: "${{ variables.target_id != blank }}"
+    type: kibana.request
+    with:
+      method: GET
+      path: /api/data_views
+    on-failure:
+      continue: true
+
+  - name: check_data_view
+    type: data.set
+    with:
+      existing_data_view_id: |-
+        {%- assign hit = '' -%}
+        {%- for v in steps.find_data_view.output.data_view -%}
+          {%- if v.title == consts.index -%}{%- assign hit = v.id -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {{ hit }}
+
+  # Duplicate create returns 400, not 409, so on-failure:continue absorbs a race safely.
+  - name: create_data_view
+    if: "${{ variables.target_id != blank and variables.existing_data_view_id == blank }}"
+    type: kibana.request
+    with:
+      method: POST
+      path: /api/data_views/data_view
+      headers:
+        kbn-xsrf: "true"
+        Content-Type: application/json
+      body:
+        data_view:
+          id: "{{ consts.index }}"
+          title: "{{ consts.index }}"
+          name: "{{ consts.index }}"
+          timeFieldName: "@timestamp"
+          allowNoIndex: true
+    on-failure:
+      continue: true
+
+  - name: resolve_data_view
+    type: data.set
+    with:
+      data_view_id: |-
+        {%- if variables.existing_data_view_id != blank -%}{{ variables.existing_data_view_id }}
+        {%- elsif steps.create_data_view.output.data_view.id != blank -%}{{ steps.create_data_view.output.data_view.id }}
+        {%- endif -%}
+
+  - name: build_targets
+    type: data.parseJson
+    source: |-
+      [
+      {%- assign sep = '' -%}
+      {%- if event.alerts[0] != blank -%}
+        {%- assign fields = consts.observable_fields -%}
+        {%- assign seen = consts.empty_arr -%}
+        {%- for f in fields -%}
+          {%- assign parts = f | strip | split: '.' -%}
+          {%- assign node = event.alerts[0] -%}
+          {%- for p in parts -%}{%- assign node = node[p] -%}{%- endfor -%}
+          {%- if node != blank -%}
+            {%- unless seen contains node -%}
+              {{ sep }}{"field":"{{ f | strip }}","value":"{{ node }}"}
+              {%- assign sep = ',' -%}
+              {%- assign seen = seen | push: node -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elsif inputs.url != blank -%}
+        {"field":"manual","value":"{{ inputs.url | strip }}"}
+      {%- endif -%}
+      ]
+    with: {}
+
+  - name: no_targets
+    type: if
+    condition: "${{ steps.build_targets.output.size == 0 }}"
+    steps:
+      - name: log_no_targets
+        type: console
+        with:
+          message: >-
+            No usable URL found. Checked {{ consts.observable_fields | join: ', ' }} on
+            the alert and the url input. Nothing to scan.
+
+  - name: scan_each_url
+    type: foreach
+    foreach: "${{ steps.build_targets.output }}"
+    steps:
+
+      - name: stash_observable
+        type: data.set
+        with:
+          observable: "{{ foreach.item.value }}"
+          field_name: "{{ foreach.item.field }}"
+          doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | sha256 }}"
+          failure_doc_id: "{{ variables.target_id | default: 'manual' | append: '-' | append: foreach.item.value | append: '-run-summary' | sha256 }}"
+
+      # --- 1. Submit ------------------------------------------------------
+      # scanUrl takes only `url` - no optional parameters, unlike scanPrivateUrl.
+      - name: submit_scan
+        type: google_threat_intelligence.scanUrl
+        connector-id: "{{ consts.gti_connector_id }}"
+        with:
+          url: "{{ variables.observable }}"
+        on-failure:
+          retry:
+            max-attempts: 2
+            delay: 3s
+          continue: true
+
+      - name: submission_failed
+        type: if
+        condition: "${{ steps.submit_scan.error != blank or steps.submit_scan.output.data.id == blank }}"
+        steps:
+          - name: log_submission_error
+            type: console
+            with:
+              message: |-
+                STATUS: failed - GTI scanUrl failed for {{ variables.field_name }} ({{ variables.observable }}).
+                {{ steps.submit_scan.error | json }}
+
+          - name: write_submission_failure
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_public
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ steps.submit_scan.error.message }}"
+                  type: "{{ steps.submit_scan.error.type }}"
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+            on-failure:
+              continue: true
+
+          # Path 1/2 only - a standalone run has no alert to annotate.
+          - name: annotate_alert_submission_failure
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_submission_failure
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: prepare_submission_failure_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Public): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_submission_failure.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Public): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Public) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{%- if variables.url_report_id != blank -%}{{ variables.url_report_id }}{%- else -%}{{ variables.observable | sha256 }}{%- endif -%})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** The scan could not be submitted to GTI.
+                    > `{{ steps.submit_scan.error.message }}`
+                    > See the indexed failure record for detail: index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+
+              - name: write_submission_failure_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_submission_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_submission_failure_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration_on_submission_failure
+            type: loop.continue
+
+      # --- 2. Poll ----------------------------------------------------
+      # Same shape as GTI URL Scan (Private), including both live-caught fixes
+      # from that workflow applied from the start here: poll immediately, wait
+      # only if still not done, gated by an explicit `if` on the tracked id,
+      # max-iterations 60 at a 10s interval (10-minute ceiling, modeled on
+      # Censys's shipped Rescan workflow) - and getAnalysis's meta.url_info.id
+      # is read as a sibling of data, not nested under it, from the start.
+      - name: init_polling
+        type: data.set
+        with:
+          analysis_id: "{{ steps.submit_scan.output.data.id }}"
+          scan_status: ""
+          url_report_id: ""
+
+      - name: poll_scan_status_gate
+        type: if
+        condition: "${{ variables.analysis_id != blank }}"
+        steps:
+          - name: poll_until_complete
+            type: while
+            # queued / in-progress / blank (not yet reported) keep polling;
+            # anything else - completed, poll_error, or any status word GTI
+            # might add later that this workflow doesn't recognize - stops
+            # the loop rather than spinning on an unrecognized value.
+            condition: "${{ variables.scan_status == '' or variables.scan_status == 'queued' or variables.scan_status == 'in-progress' }}"
+            max-iterations: 60   # literal only (see rescan.yaml); keep this and the note text below in sync
+            steps:
+              - name: get_analysis
+                type: google_threat_intelligence.getAnalysis
+                connector-id: "{{ consts.gti_connector_id }}"
+                with:
+                  analysisId: "{{ variables.analysis_id }}"
+                on-failure:
+                  retry:
+                    max-attempts: 2
+                    delay: 3s
+                  continue: true
+
+              - name: record_poll_success
+                type: if
+                condition: "${{ steps.get_analysis.error == blank }}"
+                steps:
+                  - name: stash_status
+                    type: data.set
+                    with:
+                      scan_status: "{{ steps.get_analysis.output.data.attributes.status }}"
+                      url_report_id: "{{ steps.get_analysis.output.meta.url_info.id | default: variables.url_report_id }}"
+
+              - name: record_poll_error
+                type: if
+                condition: "${{ steps.get_analysis.error != blank }}"
+                steps:
+                  - name: stash_poll_error
+                    type: data.set
+                    with:
+                      scan_status: "poll_error"
+                      poll_error_message: "{{ steps.get_analysis.error.message }}"
+                      poll_error_type: "{{ steps.get_analysis.error.type }}"
+
+              - name: wait_if_not_done
+                type: if
+                condition: "${{ variables.scan_status == 'queued' or variables.scan_status == 'in-progress' }}"
+                steps:
+                  - name: wait_between_polls
+                    type: wait
+                    with:
+                      duration: 10s
+
+      # --- 3. Retrieve, only if the poll loop reached a usable completion -
+      - name: classify_poll_outcome
+        type: data.set
+        with:
+          # "completed but no meta.url_info.id" is treated the same as
+          # "still pending" (falls to the else branch below) rather than as
+          # its own error case - conservative on purpose.
+          scan_outcome: |-
+            {%- if variables.scan_status == 'completed' and variables.url_report_id != blank -%}ready
+            {%- elsif variables.scan_status == 'poll_error' -%}error
+            {%- else -%}pending
+            {%- endif -%}
+
+      - name: retrieve_report
+        type: if
+        condition: "${{ variables.scan_outcome == 'ready' }}"
+        steps:
+          - name: get_url_scan_report
+            type: google_threat_intelligence.getUrlScanReport
+            connector-id: "{{ consts.gti_connector_id }}"
+            with:
+              urlId: "{{ variables.url_report_id }}"
+            on-failure:
+              retry:
+                max-attempts: 2
+                delay: 3s
+              continue: true
+
+          - name: stash_retrieval_success
+            type: if
+            condition: "${{ steps.get_url_scan_report.error == blank }}"
+            steps:
+              - name: stash_attrs
+                type: data.set
+                with:
+                  attrs: "${{ steps.get_url_scan_report.output.data.attributes }}"
+                  retrieval_ok: true
+
+          - name: stash_retrieval_error
+            type: if
+            condition: "${{ steps.get_url_scan_report.error != blank }}"
+            steps:
+              - name: stash_retrieval_error_detail
+                type: data.set
+                with:
+                  retrieval_ok: false
+                  retrieval_error_message: "{{ steps.get_url_scan_report.error.message }}"
+                  retrieval_error_type: "{{ steps.get_url_scan_report.error.type }}"
+
+      - name: compute_run_status
+        type: data.set
+        with:
+          run_status: |-
+            {%- if variables.scan_outcome == 'ready' and variables.retrieval_ok == true -%}succeeded
+            {%- elsif variables.scan_outcome == 'error' or variables.retrieval_ok == false -%}failed
+            {%- else -%}partial
+            {%- endif -%}
+
+      - name: log_run_status
+        type: console
+        with:
+          message: |-
+            STATUS: {{ variables.run_status }} - GTI URL Scan (Public) for {{ variables.observable }}. Analysis id: {{ variables.analysis_id }}. Last poll status: {{ variables.scan_status }}.
+
+      # --- 4a. failed: run-summary doc, failure note, no tag, skip rest ---
+      - name: handle_failed
+        type: if
+        condition: "${{ variables.run_status == 'failed' }}"
+        steps:
+          - name: write_run_summary_failed
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_public
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: "{{ variables.poll_error_message | default: variables.retrieval_error_message }}"
+                  type: "{{ variables.poll_error_type | default: variables.retrieval_error_type }}"
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                scan:
+                  analysis_id: "{{ variables.analysis_id }}"
+                  last_status: "{{ variables.scan_status }}"
+            on-failure:
+              continue: true
+
+          - name: annotate_alert_failed
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_failed
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_failure_doc_link
+                type: data.set
+                with:
+                  failure_doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.failure_doc_id }}
+                    {%- endif -%}
+
+              - name: prepare_failed_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Public): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_failed.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Public): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Public) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{%- if variables.url_report_id != blank -%}{{ variables.url_report_id }}{%- else -%}{{ variables.observable | sha256 }}{%- endif -%})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: failed.** Analysis id `{{ variables.analysis_id }}`. {% if variables.scan_outcome == 'error' %}Polling GTI for this analysis's status failed.{% else %}Retrieving the completed report from GTI failed.{% endif %}
+                    > `{{ variables.poll_error_message | default: variables.retrieval_error_message }}`
+                    > See the indexed failure record for detail: {% if variables.failure_doc_link != blank %}[open in Discover](<{{ variables.failure_doc_link }}>){% else %}index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_failed_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_failed_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_failed_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+          - name: skip_iteration_on_failure
+            type: loop.continue
+
+      # --- 4b. partial: run-summary doc, "still processing" note, tagged --
+      - name: handle_partial
+        type: if
+        condition: "${{ variables.run_status == 'partial' }}"
+        steps:
+          - name: write_run_summary_partial
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.failure_doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_public
+                  outcome: failure
+                doc_type: fetch_failure
+                error:
+                  message: ""
+                  type: ""
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                scan:
+                  analysis_id: "{{ variables.analysis_id }}"
+                  last_status: "{{ variables.scan_status }}"
+                  timed_out: true
+            on-failure:
+              continue: true
+
+          - name: annotate_alert_partial
+            type: if
+            condition: "${{ variables.target_id != blank }}"
+            steps:
+              - name: find_existing_note_partial
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: prepare_partial_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Public): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_partial.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Public): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Public) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{%- if variables.url_report_id != blank -%}{{ variables.url_report_id }}{%- else -%}{{ variables.observable | sha256 }}{%- endif -%})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    > **STATUS: partial.** The scan was submitted successfully (analysis id `{{ variables.analysis_id }}`), but GTI had not finished analyzing it after 60 status checks (~10 minutes). Last known status: `{{ variables.scan_status }}`. This is not a failure - GTI may still be working on it. Re-run this workflow later to check again, or poll `getAnalysis`/`getUrlScanReport` directly with this analysis id.
+                    > Indexed to `{{ consts.index }}`, document
+                    ```
+                    {{ variables.failure_doc_id }}
+                    ```
+
+              - name: write_partial_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_partial_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_partial_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+              # Real work happened - a scan was genuinely submitted and is in flight -
+              # so this still gets tagged, same as a paginated workflow's partial batch.
+              - name: tag_alert_partial
+                type: security.setAlertTags
+                with:
+                  alert_ids: "{{ variables.target_id }}"
+                  tags_to_add:
+                    - "gti:url-scan-public"
+                on-failure:
+                  continue: true
+
+          - name: standalone_log_partial
+            type: if
+            condition: "${{ variables.target_id == blank }}"
+            steps:
+              - name: log_partial_standalone
+                type: console
+                with:
+                  message: |-
+                    STATUS: partial - GTI still processing {{ variables.observable }} after 60 status checks (~10 minutes). Analysis id: {{ variables.analysis_id }}. Re-run later or poll directly with this id.
+
+          - name: skip_iteration_on_partial
+            type: loop.continue
+
+      # --- 4c. succeeded: full report, index, note, tag ------------------
+      # categories is a vendor-name-keyed map, flattened via entries so a new
+      # vendor never grows this summary block's own field count.
+      #
+      # has_analysis_stats/has_reputation/has_votes gate the note the same
+      # defensive way GTI URL Scan (Private) does - carried over from the
+      # start here rather than re-discovered, since whether a fresh public
+      # scan populates these fields any faster than a private one is not
+      # assumed true without its own live check (see
+      # gti-workflow-url-scan.md §3).
+      - name: summarise
+        type: data.set
+        with:
+          verdict: "{{ variables.attrs.gti_assessment.verdict.value | default: 'UNKNOWN' }}"
+          severity: "{{ variables.attrs.gti_assessment.severity.value | default: 'UNKNOWN' }}"
+          threat_score: "{{ variables.attrs.gti_assessment.threat_score.value | default: 0 }}"
+          description: "{{ variables.attrs.gti_assessment.description | replace: '\n', ' ' | replace: '  ', ' ' | strip }}"
+          has_analysis_stats: "${{ variables.attrs.last_analysis_stats != blank }}"
+          malicious_count: "{{ variables.attrs.last_analysis_stats.malicious | default: 0 }}"
+          suspicious_count: "{{ variables.attrs.last_analysis_stats.suspicious | default: 0 }}"
+          harmless_count: "{{ variables.attrs.last_analysis_stats.harmless | default: 0 }}"
+          undetected_count: "{{ variables.attrs.last_analysis_stats.undetected | default: 0 }}"
+          last_analysis_date: "{{ variables.attrs.last_analysis_date }}"
+          has_reputation: "${{ variables.attrs.reputation != blank }}"
+          reputation: "{{ variables.attrs.reputation | default: 0 }}"
+          has_votes: "${{ variables.attrs.total_votes != blank }}"
+          votes_harmless: "{{ variables.attrs.total_votes.harmless | default: 0 }}"
+          votes_malicious: "{{ variables.attrs.total_votes.malicious | default: 0 }}"
+          title: "{{ variables.attrs.title }}"
+          tld: "{{ variables.attrs.tld }}"
+          web_category: "{{ variables.attrs.web_category }}"
+          tags: "${{ variables.attrs.tags }}"
+          threat_names: "${{ variables.attrs.threat_names | default: consts.empty_arr }}"
+          crowdsourced_context: "${{ variables.attrs.crowdsourced_context | default: consts.empty_arr }}"
+          categories_list: |-
+            {%- assign cats = variables.attrs.categories | default: consts.empty_arr | entries -%}
+            {%- for pair in cats -%}
+              {%- if forloop.first == false %}, {% endif -%}{{ pair.key }}: {{ pair.value }}
+            {%- endfor -%}
+
+      - name: index_scan_result
+        type: if
+        condition: "${{ variables.run_status == 'succeeded' }}"
+        steps:
+          - name: index_enrichment
+            type: elasticsearch.index
+            with:
+              index: "{{ consts.index }}"
+              id: "{{ variables.doc_id }}"
+              document:
+                "@timestamp": "{{ execution.startedAt | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                event:
+                  kind: enrichment
+                  category: threat
+                  dataset: gti_soar.url_scan_public
+                observable:
+                  type: url
+                  field: "{{ variables.field_name }}"
+                  value: "{{ variables.observable }}"
+                trigger_mode: "{{ variables.trigger_mode }}"
+                kibana:
+                  alert:
+                    uuid: "{{ variables.target_id }}"
+                    index: "{{ variables.target_index }}"
+                rule:
+                  id: "{{ variables.rule_id }}"
+                  name: "{{ variables.rule_name }}"
+                workflow:
+                  execution_id: "{{ execution.id }}"
+                scan:
+                  analysis_id: "{{ variables.analysis_id }}"
+                  private: "${{ variables.attrs.private | default: false }}"
+                summary:
+                  verdict: "{{ variables.verdict }}"
+                  severity: "{{ variables.severity }}"
+                  description: "{{ variables.description }}"
+                  threat_score: "${{ variables.threat_score | plus: 0 }}"
+                  # false, not just an absent field, so "engines haven't run yet" is distinguishable
+                  # from "confirmed 0 detections" without having to compare against last_analysis_date too.
+                  analysis_stats_available: "${{ variables.has_analysis_stats }}"
+                  reputation_available: "${{ variables.has_reputation }}"
+                  votes_available: "${{ variables.has_votes }}"
+                  malicious_count: "${{ variables.malicious_count | plus: 0 }}"
+                  suspicious_count: "${{ variables.suspicious_count | plus: 0 }}"
+                  harmless_count: "${{ variables.harmless_count | plus: 0 }}"
+                  undetected_count: "${{ variables.undetected_count | plus: 0 }}"
+                  last_analysis_date: "{{ variables.last_analysis_date | date: '%Y-%m-%dT%H:%M:%S.%L%z' }}"
+                  reputation: "${{ variables.reputation | plus: 0 }}"
+                  votes_harmless: "${{ variables.votes_harmless | plus: 0 }}"
+                  votes_malicious: "${{ variables.votes_malicious | plus: 0 }}"
+                  title: "{{ variables.title }}"
+                  tld: "{{ variables.tld }}"
+                  web_category: "{{ variables.web_category }}"
+                  categories: "{{ variables.categories_list }}"
+                  tags: "${{ variables.tags }}"
+                  threat_names: "${{ variables.threat_names }}"
+                  crowdsourced_context: "${{ variables.crowdsourced_context }}"
+                gti: "${{ steps.get_url_scan_report.output.data }}"
+            on-failure:
+              continue: true
+
+          # Paths 1/2 only, and only once the document actually exists.
+          - name: annotate_alert_succeeded
+            type: if
+            condition: "${{ variables.target_id != blank and steps.index_enrichment.error == blank }}"
+            steps:
+
+              - name: find_existing_note_succeeded
+                type: kibana.request
+                with:
+                  method: GET
+                  path: /api/note
+                  query:
+                    documentIds: "{{ variables.target_id }}"
+                on-failure:
+                  continue: true
+
+              - name: build_doc_link
+                type: data.set
+                with:
+                  doc_link: |-
+                    {%- if variables.data_view_id != blank -%}
+                      {%- assign sp = '' -%}
+                      {%- if workflow.spaceId != blank and workflow.spaceId != 'default' -%}{%- assign sp = '/s/' | append: workflow.spaceId -%}{%- endif -%}
+                      {{ sp }}/app/discover#/doc/{{ variables.data_view_id }}/{{ consts.index }}?id={{ variables.doc_id }}
+                    {%- endif -%}
+
+              - name: prepare_succeeded_note
+                type: data.set
+                with:
+                  existing_note_id: |-
+                    {%- assign marker = 'GTI URL Scan (Public): ' | append: variables.observable -%}
+                    {%- for n in steps.find_existing_note_succeeded.output.notes -%}
+                      {%- if n.note contains marker -%}{{ n.noteId }}{%- endif -%}
+                    {%- endfor -%}
+                  note_text: |-
+                    ## GTI URL Scan (Public): {{ variables.observable }}
+
+                    _Managed by the GTI URL Scan (Public) workflow. This note is replaced on every run; record your own analysis in a separate note._
+
+                    Observed on `{{ variables.field_name }}` - [View URL on GTI]({{ consts.gti_ui_base }}/{%- if variables.url_report_id != blank -%}{{ variables.url_report_id }}{%- else -%}{{ variables.observable | sha256 }}{%- endif -%})
+                    Run [{{ workflow.name }}:{{ execution.id }}]({{ execution.url }})
+
+                    ---
+
+                    **STATUS: succeeded.**
+
+                    ### Scan submission
+                    - **Analysis id:** {{ variables.analysis_id }}
+
+                    ### Assessment
+                    - **Verdict:** {{ variables.verdict }}
+                    - **Severity:** {{ variables.severity }}
+                    - **Threat score:** {{ variables.threat_score }}
+                    {%- if variables.has_reputation %}
+                    - **Reputation:** {{ variables.reputation }}
+                    {%- endif %}
+                    {%- if variables.description != blank %}
+                    - **GTI summary:** {{ variables.description }}
+                    {%- endif %}
+
+                    ### Detection
+                    {%- if variables.has_analysis_stats %}
+                    - **Last analysis:** {{ variables.malicious_count }} malicious, {{ variables.suspicious_count }} suspicious, {{ variables.harmless_count }} harmless, {{ variables.undetected_count }} undetected{% if variables.last_analysis_date != blank %} (as of {{ variables.last_analysis_date | date: '%Y-%m-%d' }}){% endif %}
+                    {%- else %}
+                    - **Multi-engine analysis:** not yet available - GTI has not completed third-party engine analysis for this scan yet. The verdict above is GTI's own assessment only; re-run this workflow later or check GTI directly for updated engine results.
+                    {%- endif %}
+                    {%- if variables.has_votes %}
+                    - **Community votes:** {{ variables.votes_harmless | default: 0 }} harmless, {{ variables.votes_malicious | default: 0 }} malicious
+                    {%- endif %}
+                    {%- if variables.threat_names.size > 0 %}
+                    - **Threat names:** {{ variables.threat_names | join: ', ' }}
+                    {%- endif %}
+                    {%- if variables.title != blank or variables.web_category != blank %}
+
+                    ### URL info
+                    {%- if variables.title != blank %}
+                    - **Page title:** {{ variables.title }}
+                    {%- endif %}
+                    {%- if variables.web_category != blank %}
+                    - **Web category:** {{ variables.web_category }}
+                    {%- endif %}
+                    {%- if variables.tld != blank %}
+                    - **TLD:** {{ variables.tld }}
+                    {%- endif %}
+                    {%- endif %}
+                    {%- if variables.categories_list != blank %}
+
+                    ### Categories
+                    - {{ variables.categories_list }}
+                    {%- endif %}
+                    {%- if variables.tags.size > 0 %}
+
+                    ### Tags
+                    - {{ variables.tags | join: ', ' }}
+                    {%- endif %}
+                    {%- if variables.crowdsourced_context.size > 0 %}
+
+                    ### Community context
+                    {%- for c in variables.crowdsourced_context %}
+                    {%- assign detail_line = c.details | replace: '\n', ' ' | replace: '  ', ' ' | strip %}
+                    - **{{ c.title }}** ({{ c.severity | default: 'unknown' }} severity, via {{ c.source }}){% if c.timestamp != blank %}, {{ c.timestamp | date: '%Y-%m-%d' }}{% endif %}: {{ detail_line }}
+                    {%- endfor %}
+                    {%- endif %}
+
+                    ---
+                    {% if variables.doc_link != blank %}Full response: [open the stored document in Discover](<{{ variables.doc_link }}>){% else %}Full response in index `{{ consts.index }}`, document
+                    ```
+                    {{ variables.doc_id }}
+                    ```
+                    {% endif %}
+
+              - name: write_succeeded_note
+                type: if
+                condition: "${{ variables.existing_note_id != blank }}"
+                steps:
+                  - name: update_succeeded_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        noteId: "{{ variables.existing_note_id }}"
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+                else:
+                  - name: create_succeeded_note
+                    type: kibana.request
+                    with:
+                      method: PATCH
+                      path: /api/note
+                      headers:
+                        kbn-xsrf: "true"
+                        Content-Type: application/json
+                      body:
+                        note:
+                          eventId: "{{ variables.target_id }}"
+                          timelineId: ""
+                          note: "{{ variables.note_text }}"
+                    on-failure:
+                      continue: true
+
+              - name: tag_alert_succeeded
+                type: security.setAlertTags
+                with:
+                  alert_ids: "{{ variables.target_id }}"
+                  tags_to_add:
+                    - "gti:url-scan-public"
+                on-failure:
+                  continue: true
+
+          # Path 3: no alert to annotate.
+          - name: report_standalone
+            type: if
+            condition: "${{ variables.target_id == blank }}"
+            steps:
+              - name: log_document_reference
+                type: console
+                with:
+                  message: |-
+                    STATUS: succeeded - GTI URL scan (public) for {{ variables.observable }}: verdict {{ variables.verdict }}, severity {{ variables.severity }}.
+                    Indexed to {{ consts.index }} / {{ variables.doc_id }}


### PR DESCRIPTION
## Description

Adds a new **Google Threat Intelligence** integration under `examples/integrations/google-threat-intelligence/` containing twelve workflows that operate against the **Google Threat Intelligence Connector**, using its `getIpReport`, `getIpRelationship`, `getDomainReport`, `getDomainRelationship`, `getUrlReport`, `getUrlRelationship`, `getFileReport`, `getFileRelationship`, `getFileBehaviours`, `getFileMitreAttackTechniques`, `scanUrl`, `getAnalysis`, `getUrlScanReport`, `scanPrivateUrl`, `getPrivateAnalysis`, and `getPrivateUrlReport` **actions**. The workflows enrich Security alerts with GTI intelligence.

Eight workflows support both **manual** and **alert** triggers. The four relationship workflows are **manual-only**: a relationship response can be far larger than any other action's, and there is no single relationship value worth choosing automatically on every alert. Every workflow indexes its results into a dedicated `gti-soar-*` index, replaces its own previous alert note rather than stacking a second copy, tags the alert, and falls back to logging to the workflow console when no write-back target is available.

| Workflow | GTI actions used | What it does |
|----------|------------------|--------------|
| GTI IP Address Report | `getIpReport` | Reputation and detection report for an IP address (verdict, threat score, last analysis stats, network ownership, geolocation, tags). Indexes to `gti-soar-ip-report`. |
| GTI IP Address Relationships | `getIpRelationship` | Objects related to an IP address by relationship type (communicating files, historical resolutions, hosted URLs). Indexes each related object as its own document in `gti-soar-ip-relationship`. Manual only. |
| GTI Domain Report | `getDomainReport` | Reputation and detection report for a domain (verdict, threat score, registrar/WHOIS, categorisation, popularity ranks, tags). Indexes to `gti-soar-domain-report`. |
| GTI Domain Relationships | `getDomainRelationship` | Objects related to a domain (subdomains, historical resolutions, communicating files; 30 relationship values). Indexes to `gti-soar-domain-relationship`. Manual only. |
| GTI URL Report | `getUrlReport` | Reputation and detection report for a URL (verdict, threat score, final resolved destination, HTTP response metadata, categorisation, tags). Indexes to `gti-soar-url-report`. |
| GTI URL Relationships | `getUrlRelationship` | Objects related to a URL (redirects, contacted domains, downloaded files; 31 relationship values). Indexes to `gti-soar-url-relationship`. Manual only. |
| GTI File Hash Report | `getFileReport` | Reputation and detection report for a file hash (verdict, threat score, popular threat classification, file type metadata, signature info, tags). Indexes to `gti-soar-file-report`. |
| GTI File Hash Relationships | `getFileRelationship` | Objects related to a file (contacted domains, dropped files, sandbox behaviours; 49 relationship values, the largest of the four relationship actions). Indexes to `gti-soar-file-relationship`. Manual only. |
| GTI File Sandbox Behaviour | `getFileBehaviours` | Sandbox detonation reports for a file hash, paging via `limit`/`cursor` until GTI has no more to give. Indexes every report as its own document in `gti-soar-file-behaviour` and renders one note section per report. |
| GTI MITRE ATT&CK Techniques | `getFileMitreAttackTechniques` | MITRE ATT&CK tactics and techniques GTI observed for a file hash, grouped by sandbox. Indexes to `gti-soar-mitre-attack`. |
| GTI URL Scan (Public) | `scanUrl`, `getAnalysis`, `getUrlScanReport` | Submit→poll→retrieve a fresh public analysis for a URL, chaining three actions in one execution. Indexes to `gti-soar-url-scan-public`; the note links to GTI's public GUI page. |
| GTI URL Scan (Private) | `scanPrivateUrl`, `getPrivateAnalysis`, `getPrivateUrlReport` | Same submit→poll→retrieve pipeline, but the URL and resulting analysis are not shared with the wider GTI community. Indexes to `gti-soar-url-scan-private`. |

## Depends on

* These workflows invoke the **actions of the Google Threat Intelligence connector** (`getIpReport`, `getIpRelationship`, `getDomainReport`, `getDomainRelationship`, `getUrlReport`, `getUrlRelationship`, `getFileReport`, `getFileRelationship`, `getFileBehaviours`, `getFileMitreAttackTechniques`, `scanUrl`, `getAnalysis`, `getUrlScanReport`, `scanPrivateUrl`, `getPrivateAnalysis`, `getPrivateUrlReport`), which are added in that PR. It must be merged/available before these workflows can run.

    [\[Connector\]\[GTI\] Add Google Threat Intelligence connector kibana#285533](https://github.com/elastic/kibana/pull/285533)

    As of this writing the connector ships only on the `google_threat_intelligence-connector` branch, not on `main` and not in any released build. These workflows fail at the connector-resolution step on a stock Kibana instance until that PR merges, so the real compatibility bar is "Kibana 9.6.0 with that connector merged," not 9.6.0 alone.

## Required Permissions / Setup

* **Google Threat Intelligence connector** configured in Kibana with a GTI **Enterprise**-tier API key. The connector's Test action fails with a clear message on a lower tier, because `gti_assessment` is absent from responses. Set `consts.gti_connector_id` in each workflow to the connector's id.
* **Elastic license**: Enterprise. **Elastic Stack**: 9.6.0 or later.
* **Analytics > Workflows**: `All` to create and run, `Read` to view.
* **Security > Alerts**: read on the alert indices to fetch the observable, and write for the tag step.
* **Security > Notes**: both `notes_read` and `notes_write`. Read is used to find a previous note so a re-run replaces it rather than stacking a second copy; write to save it.
* **Index privileges**: `write` on `gti-soar-*`. The data view and index template are created automatically; no manual setup is needed.
* Each workflow reads observables from `consts.observable_fields`, resolved by dotted path at run time. Defaults are provided per observable type and are meant to be adjusted; no step needs editing when entries are added or removed.
* When attaching any alert-triggered workflow as a rule action, enable the **"Run per alert"** toggle. In summary mode the alert batch arrives together and the workflow processes only the observables of the alerts in that batch.

## Testing

- [x] Tested in Kibana 9.6.0 against the real GTI API with an Enterprise key
- [x] YAML validates without errors / imports cleanly
- [x] Each workflow executes successfully across all three paths it supports (detection rule, manual against an alert, manual standalone)
- [x] Write-back verified: destination index document, alert note replacement on re-run, and alert tag
- [x] Note rendering verified, including the heading-plus-bullet-list shape used instead of markdown tables, since the alert note list renders without `remark-gfm` and pipe-table syntax shows as literal broken text there
- [x] Pagination verified on File Sandbox Behaviour and all four relationship workflows
- [x] Polling verified on both URL Scan workflows
- [x] Error handling verified when the GTI API fails or returns an empty result

## Checklist

- [x] Descriptive `name` + multi-sentence `description` metadata on every workflow
- [x] Section comments included
- [x] Step comments included
- [x] No real credentials/secrets
- [x] Integration README added