### PR TITLE
fix(rca): use top-level kibanaUrl instead of context.kibanaUrl

### DIFF
--- a/examples/observability/root-cause-analysis-rca-workflow.yaml
+++ b/examples/observability/root-cause-analysis-rca-workflow.yaml
@@ -220,7 +220,7 @@ steps:
       case_id: "{{ steps.create_case.output.case.id }}"
       comment: |
         ## 🔍 AI Investigation Summary
-        [View Full Conversation]({{ context.kibanaUrl }}/app/agent_builder/conversations/{{ steps.getConversation.output.id }})
+        [View Full Conversation]({{ kibanaUrl }}/app/agent_builder/conversations/{{ steps.getConversation.output.id }})
 
         ### Investigation Steps
 
@@ -253,7 +253,7 @@ steps:
         {%- if has_error %}
         - ❌ **Error:** {{ error_message }}
         {%- elsif query_esql != "" %}
-        - ✅ **Found {{ result_count }} results** → [View in Discover]({{ context.kibanaUrl }}/{{consts.basePath}}app/discover#/?_a=(dataSource:(type:esql),query:(esql:'{{ query_esql | url_encode }}')))
+        - ✅ **Found {{ result_count }} results** → [View in Discover]({{ kibanaUrl }}/{{consts.basePath}}app/discover#/?_a=(dataSource:(type:esql),query:(esql:'{{ query_esql | url_encode }}')))
         {%- else %}
         - ✅ **Completed**
         {%- endif %}

--- a/library/workflows/root-cause-analysis/root-cause-analysis.yaml
+++ b/library/workflows/root-cause-analysis/root-cause-analysis.yaml
@@ -1,6 +1,6 @@
 template-metadata:
   slug: root-cause-analysis
-  version: "1.0.0"
+  version: "1.0.1"
   availability: ">=9.5.0"
   name: "Root Cause Analysis (Agent Builder)"
   description: >-
@@ -103,7 +103,7 @@ steps:
       case_id: "{{ steps.create_case.output.case.id }}"
       comment: |
         ## 🔍 AI Investigation Summary
-        [View Full Conversation]({{ context.kibanaUrl }}/app/agent_builder/conversations/{{ steps.get_conversation.output.id }})
+        [View Full Conversation]({{ kibanaUrl }}/app/agent_builder/conversations/{{ steps.get_conversation.output.id }})
 
         ### Investigation Steps
 
@@ -136,7 +136,7 @@ steps:
         {%- if has_error %}
         - ❌ **Error:** {{ error_message }}
         {%- elsif query_esql != "" %}
-        - ✅ **Found {{ result_count }} results** → [View in Discover]({{ context.kibanaUrl }}/app/discover#/?_a=(dataSource:(type:esql),query:(esql:'{{ query_esql | url_encode }}')))
+        - ✅ **Found {{ result_count }} results** → [View in Discover]({{ kibanaUrl }}/app/discover#/?_a=(dataSource:(type:esql),query:(esql:'{{ query_esql | url_encode }}')))
         {%- else %}
         - ✅ **Completed**
         {%- endif %}


### PR DESCRIPTION
Fixes #50. Replace context.kibanaUrl with top-level kibanaUrl in RCA library template and observability example (4 sites). Bump template version to 1.0.1. Matches traditional-triage.yaml. Runtime links were empty; editor blocked Enable.