### PR TITLE
[Library] Allow publishing the catalog to the staging CDN

### DIFF
--- a/.buildkite/pipelines/publish_catalog.yml
+++ b/.buildkite/pipelines/publish_catalog.yml
@@ -2,9 +2,14 @@
 #
 # Registered via catalog-info.yaml (Backstage). Runs on merge to `main` and
 # publishes the generated catalog to the production CDN bucket.
+#
+# To publish a staging preview instead, create a build by hand with
+# `PUBLISH_TARGET=staging` in its environment. The target is interpolated when
+# the pipeline is uploaded, so the resolved bucket shows up in the step label;
+# `publish_catalog.sh` rejects anything other than `prod` or `staging`.
 steps:
-  - label: ":cloud: Publish catalog → workflows.elastic.co"
-    command: .buildkite/scripts/publish_catalog.sh prod
+  - label: ":cloud: Publish catalog → ${PUBLISH_TARGET:-prod} CDN"
+    command: .buildkite/scripts/publish_catalog.sh ${PUBLISH_TARGET:-prod}
     timeout_in_minutes: 20
     agents:
       # Kibana-owned CI image with node + Cloud SDK (gcloud) + vault preinstalled


### PR DESCRIPTION
## Summary

`publish_catalog.sh` has always taken a `prod|staging` argument and carries the staging bucket and CDN base, but the pipeline hardcoded `prod` — so the staging path was unreachable and has never run. This reads the target from `PUBLISH_TARGET`, defaulting to `prod`.

Merge-triggered builds are unchanged: `PUBLISH_TARGET` is unset there, so the default applies and the catalog goes to `workflows.elastic.co` exactly as before. To publish a preview, create a build by hand on the pipeline with `PUBLISH_TARGET=staging` in its environment.

The target is also interpolated into the step label, so a hand-created build reads "Publish catalog → staging CDN" before it writes anything — the label is rendered at pipeline-upload time, which makes it a cheap confirmation that the override took effect.

## Testing

- The pipeline YAML parses, and the step resolves to `.buildkite/scripts/publish_catalog.sh ${PUBLISH_TARGET:-prod}` with the label carrying the same default.
- `publish_catalog.sh bogus` exits 1 with `Unknown target 'bogus'` before touching credentials or buckets, so a typo in the env var cannot publish to the wrong place.
- An empty value takes the `prod` default, which is the path a merge-triggered build follows.

Note that no CI job has written to `elastic-workflows-library-staging` before — the content currently there predates this pipeline — so the publisher service account's write access to that bucket is unverified. If the `gcloud storage rsync` step 403s, the SA behind `kv/ci-shared/workflows-library/gcs-publish` needs object-admin on it. A staging build never touches prod either way.

Made with [Cursor](https://cursor.com)